### PR TITLE
[bug/#8] Fixed install issue

### DIFF
--- a/docs/operations/webhook-foreign-key-fix-20260321.md
+++ b/docs/operations/webhook-foreign-key-fix-20260321.md
@@ -1,0 +1,109 @@
+# Bug Fix: Foreign Key Constraint on installation_repositories Webhook
+
+**Date:** March 21, 2026  
+**Status:** Resolved  
+**Severity:** Critical - Webhook processing failing
+
+## Issue Summary
+
+After deploying the consolidated migration, the bot started receiving `installation_repositories.added` webhooks from GitHub but failed to process them with error:
+
+```
+Foreign key constraint violated on the fields: (`installationId`)
+Invalid `prisma.repository.upsert()` invocation
+```
+
+## Root Cause
+
+When GitHub sends the `installation_repositories.added` event (which happens when repositories are added to an existing GitHub App installation), the webhook handler tried to upsert repositories that reference an `installationId` in the `github_installations` table.
+
+**The Problem:**
+- The `upsertInstallationRepositories` function assumed the installation record already existed
+- If the installation record didn't exist in the database, the foreign key constraint would fail
+- This could happen if:
+  - The app missed the `installation.created` webhook
+  - The database was cleared/reset after installation
+  - The installation was created before the bot was deployed
+
+## Solution
+
+Modified the `upsertInstallationRepositories` function to **ensure the installation record exists** before attempting to upsert repositories:
+
+1. **First:** Upsert the `github_installations` record
+   - Creates it if it doesn't exist
+   - Updates `accountLogin` if provided and record exists
+   - Uses minimal data if creating (can be updated later by full installation webhook)
+
+2. **Then:** Upsert the repositories as normal
+
+## Changes Made
+
+### 1. Updated `upsertInstallationRepositories` Function
+
+**File:** [src/services/installations.ts](src/services/installations.ts)
+
+- Added optional `accountLogin` parameter
+- Added installation record upsert at the beginning of the transaction
+- Installation is created with minimal data if it doesn't exist
+- `accountLogin` is updated if provided and installation exists
+
+### 2. Updated Webhook Handlers
+
+**File:** [src/routes/webhooks.ts](src/routes/webhooks.ts)
+
+- `installation_repositories.added` handler now passes `accountLogin`
+- `installation_repositories.removed` handler now passes `accountLogin`
+- Both handlers extract account info from `payload.installation.account`
+
+## Impact
+
+✅ **Webhooks now process successfully** - No more foreign key constraint errors  
+✅ **Graceful handling** - Works even if installation record is missing  
+✅ **Data consistency** - Installation records are automatically created when needed  
+✅ **No data loss** - All repository additions/removals are properly tracked  
+
+## Testing
+
+To verify the fix works:
+
+1. **Add a repository to your GitHub App installation:**
+   - Go to GitHub App settings
+   - Select "Repository access"
+   - Add a new repository
+
+2. **Check bot logs:**
+   ```bash
+   docker logs -f bot-1 | grep "installation_repositories"
+   ```
+
+3. **Expected output:**
+   ```
+   Received GitHub webhook
+     deliveryId: "..."
+     event: "installation_repositories"
+     installationId: ...
+   Webhook processed successfully
+   ```
+
+4. **Verify database:**
+   ```sql
+   SELECT * FROM github_installations WHERE installationId = ...;
+   SELECT * FROM repositories WHERE installationId = ...;
+   ```
+
+## Prevention
+
+This issue was caught in production because:
+- Fresh database deployment
+- GitHub App had existing installations
+- Webhook events arrived before full installation data was synced
+
+**Going forward:**
+- The fix ensures webhook handlers are resilient to missing data
+- Installation records are created automatically as needed
+- Account login information is properly captured from webhook payloads
+
+## Related Issues
+
+- Migration consolidation: [docs/operations/migration-fix-20260321.md](migration-fix-20260321.md)
+- This was discovered immediately after the migration consolidation was deployed

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -261,6 +261,7 @@ export async function registerWebhookRoutes(
 
     await upsertInstallationRepositories({
       installationId: BigInt(payload.installation.id),
+      accountLogin: installationAccountLogin(payload.installation.account),
       repositoriesAdded,
       repositoriesRemoved: []
     });
@@ -289,6 +290,7 @@ export async function registerWebhookRoutes(
   webhooks.on("installation_repositories.removed", async ({ payload }: { payload: any }) => {
     await upsertInstallationRepositories({
       installationId: BigInt(payload.installation.id),
+      accountLogin: installationAccountLogin(payload.installation.account),
       repositoriesAdded: [],
       repositoriesRemoved: payload.repositories_removed.map((repo: any) => {
         const names = splitFullName(repo.full_name);

--- a/src/services/installations.ts
+++ b/src/services/installations.ts
@@ -63,10 +63,22 @@ export async function markInstallationInactive(installationId: bigint): Promise<
 
 export async function upsertInstallationRepositories(input: {
   installationId: bigint;
+  accountLogin?: string;
   repositoriesAdded: RepoInput[];
   repositoriesRemoved: RepoInput[];
 }): Promise<void> {
   await prisma.$transaction(async (tx) => {
+    // Ensure the installation record exists first to satisfy foreign key constraint
+    await tx.githubInstallation.upsert({
+      where: { installationId: input.installationId },
+      update: input.accountLogin ? { accountLogin: input.accountLogin } : {},
+      create: {
+        installationId: input.installationId,
+        accountLogin: input.accountLogin ?? "unknown"
+        // permissionsSnapshot omitted - will default to null
+      }
+    });
+
     for (const repository of input.repositoriesAdded) {
       await tx.repository.upsert({
         where: {


### PR DESCRIPTION
## Summary by Sourcery

Ensure installation repository webhooks can safely upsert repositories even when the associated installation record may not yet exist.

Bug Fixes:
- Prevent foreign key violations when processing installation_repositories webhooks by guaranteeing the installation record exists before repository upserts.

Enhancements:
- Capture and persist installation account login when handling installation repository add/remove webhooks.

Documentation:
- Add an operations runbook documenting the foreign key constraint issue with installation_repositories webhooks, its root cause, fix, and validation steps.

<!-- kumpeapps-issue-autoclose -->
Closes #8