### PR TITLE
[bug/#25] Fixed not adding collaborator on app install

### DIFF
--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -19,7 +19,7 @@ import { addRepositoryCollaborator, acceptRepositoryInvitation, checkDirectoryEx
 import { recordInvalidWebhookSignature } from "../services/webhook-security-health.js";
 import { processApprovalComment } from "../services/vm-approval.js";
 import { removeCaddyConfig } from "../services/ssh-deployer.js";
-import { getGitHubToken } from "../services/github-app-auth.js";
+import { getGitHubToken, getInstallationTokenById } from "../services/github-app-auth.js";
 import { deleteVirtualizorVm } from "../services/virtualizor.js";
 
 // Module-level webhook processor for backfill support
@@ -412,48 +412,56 @@ export async function registerWebhookRoutes(
       repositories
     });
 
-    // Add kumpeapps-bot-deploy as collaborator to each repository
-    // This allows issues to be assigned to the bot for manual initialization
-    for (const repo of repositories) {
-      try {
-        await addRepositoryCollaborator({
-          repositoryOwner: repo.owner,
-          repositoryName: repo.name,
-          username: "kumpeapps-bot-deploy",
-          permission: "push"
-        });
-        app.log.info(
-          { owner: repo.owner, repo: repo.name },
-          "Added kumpeapps-bot-deploy as collaborator"
-        );
-
-        // Auto-accept the invitation (for personal repos where invitation is pending)
-        const accepted = await acceptRepositoryInvitation({
-          repositoryOwner: repo.owner,
-          repositoryName: repo.name
-        });
-        if (accepted) {
-          app.log.info(
-            { owner: repo.owner, repo: repo.name },
-            "Auto-accepted collaborator invitation for kumpeapps-bot-deploy"
-          );
-        }
-      } catch (error) {
-        app.log.warn(
-          { owner: repo.owner, repo: repo.name, error },
-          "Failed to add kumpeapps-bot-deploy as collaborator"
-        );
-      }
-    }
-
-    // NOTE: Initialization is now triggered by:
-    // 1. Assigning an issue to kumpeapps-bot-deploy and running `/bot initialize` command, OR
-    // 2. Creating a .kumpeapps-deploy-bot directory in the repo
-    // This allows org-wide installation without affecting all repos automatically.
     app.log.info(
       { repositories: repositories.map((r: { owner: string; name: string }) => `${r.owner}/${r.name}`) },
       "Installation created - awaiting initialization trigger (bot command or config directory)"
     );
+
+    // Process collaborator additions asynchronously to avoid blocking webhook response
+    // This prevents database connection timeouts when there are many repositories
+    setImmediate(async () => {
+      try {
+        const installationToken = await getInstallationTokenById(BigInt(payload.installation.id));
+
+        for (const repo of repositories) {
+          try {
+            await addRepositoryCollaborator({
+              repositoryOwner: repo.owner,
+              repositoryName: repo.name,
+              username: "kumpeapps-bot-deploy",
+              permission: "push",
+              token: installationToken ?? undefined
+            });
+            app.log.info(
+              { owner: repo.owner, repo: repo.name },
+              "Added kumpeapps-bot-deploy as collaborator"
+            );
+
+            // Auto-accept the invitation (for personal repos where invitation is pending)
+            const accepted = await acceptRepositoryInvitation({
+              repositoryOwner: repo.owner,
+              repositoryName: repo.name
+            });
+            if (accepted) {
+              app.log.info(
+                { owner: repo.owner, repo: repo.name },
+                "Auto-accepted collaborator invitation for kumpeapps-bot-deploy"
+              );
+            }
+          } catch (error) {
+            app.log.warn(
+              { owner: repo.owner, repo: repo.name, error },
+              "Failed to add kumpeapps-bot-deploy as collaborator"
+            );
+          }
+        }
+      } catch (error) {
+        app.log.error(
+          { installationId: payload.installation.id, error },
+          "Critical error in collaborator addition background task"
+        );
+      }
+    });
   });
 
   webhooks.on("installation.deleted", async ({ payload }: { payload: any }) => {
@@ -508,47 +516,49 @@ export async function registerWebhookRoutes(
       repositoriesRemoved: []
     });
 
-    // Add kumpeapps-bot-deploy as collaborator to enable issue assignment
-    for (const repo of repositoriesAdded) {
-      try {
-        await addRepositoryCollaborator({
-          repositoryOwner: repo.owner,
-          repositoryName: repo.name,
-          username: "kumpeapps-bot-deploy",
-          permission: "push"
-        });
-        app.log.info(
-          { owner: repo.owner, repo: repo.name },
-          "Added kumpeapps-bot-deploy as collaborator"
-        );
-
-        // Auto-accept the invitation (for personal repos where invitation is pending)
-        const accepted = await acceptRepositoryInvitation({
-          repositoryOwner: repo.owner,
-          repositoryName: repo.name
-        });
-        if (accepted) {
-          app.log.info(
-            { owner: repo.owner, repo: repo.name },
-            "Auto-accepted collaborator invitation for kumpeapps-bot-deploy"
-          );
-        }
-      } catch (error) {
-        app.log.warn(
-          { owner: repo.owner, repo: repo.name, error: String(error) },
-          "Failed to add kumpeapps-bot-deploy as collaborator - continuing"
-        );
-      }
-    }
-
-    // NOTE: Initialization is now triggered by:
-    // 1. Assigning an issue to kumpeapps-bot-deploy and running `/bot initialize` command, OR
-    // 2. Creating a .kumpeapps-deploy-bot directory in the repo
-    // This allows org-wide installation without affecting all repos automatically.
     app.log.info(
       { repositories: repositoriesAdded.map((r: { owner: string; name: string }) => `${r.owner}/${r.name}`) },
       "Repositories added to installation - awaiting initialization trigger"
     );
+
+    // Process collaborator additions asynchronously to avoid blocking webhook response
+    // This prevents database connection timeouts when there are many repositories
+    setImmediate(async () => {
+      const installationToken = await getInstallationTokenById(BigInt(payload.installation.id));
+
+      for (const repo of repositoriesAdded) {
+        try {
+          await addRepositoryCollaborator({
+            repositoryOwner: repo.owner,
+            repositoryName: repo.name,
+            username: "kumpeapps-bot-deploy",
+            permission: "push",
+            token: installationToken ?? undefined
+          });
+          app.log.info(
+            { owner: repo.owner, repo: repo.name },
+            "Added kumpeapps-bot-deploy as collaborator"
+          );
+
+          // Auto-accept the invitation (for personal repos where invitation is pending)
+          const accepted = await acceptRepositoryInvitation({
+            repositoryOwner: repo.owner,
+            repositoryName: repo.name
+          });
+          if (accepted) {
+            app.log.info(
+              { owner: repo.owner, repo: repo.name },
+              "Auto-accepted collaborator invitation for kumpeapps-bot-deploy"
+            );
+          }
+        } catch (error) {
+          app.log.warn(
+            { owner: repo.owner, repo: repo.name, error: String(error) },
+            "Failed to add kumpeapps-bot-deploy as collaborator - continuing"
+          );
+        }
+      }
+    });
   });
 
   webhooks.on("installation_repositories.removed", async ({ payload }: { payload: any }) => {

--- a/src/services/github-app-auth.ts
+++ b/src/services/github-app-auth.ts
@@ -53,6 +53,53 @@ export function isGitHubAppAuthConfigured(): boolean {
 }
 
 /**
+ * Get an installation token directly from installation ID.
+ * Returns null if GitHub App auth is not configured.
+ * Useful when you already have the installation ID from a webhook payload.
+ */
+export async function getInstallationTokenById(installationId: bigint): Promise<string | null> {
+  if (!isGitHubAppAuthConfigured()) {
+    return null;
+  }
+
+  // Check cache first
+  const cached = tokenCache.get(installationId);
+  if (cached && cached.expiresAt > new Date()) {
+    return cached.token;
+  }
+
+  // Generate new token
+  try {
+    const privateKey = getPrivateKey();
+    if (!privateKey) {
+      return null;
+    }
+
+    const auth = createAppAuth({
+      appId: appConfig.GITHUB_APP_ID!,
+      privateKey: privateKey,
+      installationId: Number(installationId)
+    });
+
+    const { token, expiresAt } = await auth({ type: "installation" });
+
+    // Cache the token (subtract 5 minutes for safety margin)
+    const cacheExpiresAt = new Date(expiresAt);
+    cacheExpiresAt.setMinutes(cacheExpiresAt.getMinutes() - 5);
+
+    tokenCache.set(installationId, {
+      token,
+      expiresAt: cacheExpiresAt
+    });
+
+    return token;
+  } catch (error) {
+    console.error(`Failed to generate installation token for installation ${installationId}:`, error);
+    return null;
+  }
+}
+
+/**
  * Get an installation token for a specific repository.
  * Returns null if GitHub App auth is not configured or installation not found.
  */
@@ -81,43 +128,7 @@ export async function getInstallationToken(
     return null;
   }
 
-  const installationId = repo.installationId;
-
-  // Check cache first
-  const cached = tokenCache.get(installationId);
-  if (cached && cached.expiresAt > new Date()) {
-    return cached.token;
-  }
-
-  // Generate new token
-  try {
-    const privateKey = getPrivateKey();
-    if (!privateKey) {
-      return null;
-    }
-
-    const auth = createAppAuth({
-      appId: appConfig.GITHUB_APP_ID!,
-      privateKey: privateKey,
-      installationId: Number(installationId)
-    });
-
-    const { token, expiresAt } = await auth({ type: "installation" });
-
-    // Cache the token (subtract 5 minutes for safety margin)
-    const cacheExpiresAt = new Date(expiresAt);
-    cacheExpiresAt.setMinutes(cacheExpiresAt.getMinutes() - 5);
-
-    tokenCache.set(installationId, {
-      token,
-      expiresAt: cacheExpiresAt
-    });
-
-    return token;
-  } catch (error) {
-    console.error(`Failed to generate installation token for installation ${installationId}:`, error);
-    return null;
-  }
+  return getInstallationTokenById(repo.installationId);
 }
 
 /**
@@ -145,54 +156,6 @@ export async function getGitHubToken(
   // Fall back to static token
   console.log("[GitHub App Auth] Falling back to static GITHUB_API_TOKEN");
   return appConfig.GITHUB_API_TOKEN.trim();
-}
-
-/**
- * Get a GitHub API token directly by installation ID.
- * Useful for org-level operations without a specific repository.
- */
-export async function getInstallationTokenById(
-  installationId: bigint
-): Promise<string | null> {
-  if (!isGitHubAppAuthConfigured()) {
-    return null;
-  }
-
-  // Check cache first
-  const cached = tokenCache.get(installationId);
-  if (cached && cached.expiresAt > new Date()) {
-    return cached.token;
-  }
-
-  // Generate new token
-  try {
-    const privateKey = getPrivateKey();
-    if (!privateKey) {
-      return null;
-    }
-
-    const auth = createAppAuth({
-      appId: appConfig.GITHUB_APP_ID!,
-      privateKey: privateKey,
-      installationId: Number(installationId)
-    });
-
-    const { token, expiresAt } = await auth({ type: "installation" });
-
-    // Cache the token (subtract 5 minutes for safety margin)
-    const cacheExpiresAt = new Date(expiresAt);
-    cacheExpiresAt.setMinutes(cacheExpiresAt.getMinutes() - 5);
-
-    tokenCache.set(installationId, {
-      token,
-      expiresAt: cacheExpiresAt
-    });
-
-    return token;
-  } catch (error) {
-    console.error(`Failed to generate installation token for installation ${installationId}:`, error);
-    return null;
-  }
 }
 
 /**

--- a/src/services/github-automation.ts
+++ b/src/services/github-automation.ts
@@ -896,14 +896,19 @@ export async function linkIssueToBranch(input: {
 
 /**
  * Add a collaborator to a repository
+ * Uses GitHub App installation token to create the invitation
+ * For kumpeapps-bot-deploy, the invitation is then accepted via acceptRepositoryInvitation()
+ * 
+ * @param token - Optional GitHub token. If not provided, will look up installation token from database.
  */
 export async function addRepositoryCollaborator(input: {
   repositoryOwner: string;
   repositoryName: string;
   username: string;
   permission?: "pull" | "push" | "admin" | "maintain" | "triage"; // defaults to push
+  token?: string; // Optional token to avoid database lookup
 }): Promise<void> {
-  const token = await getGitHubToken(input.repositoryOwner, input.repositoryName);
+  const token = input.token ?? await getGitHubToken(input.repositoryOwner, input.repositoryName);
   if (!token) {
     throw new Error("No GitHub token available");
   }

--- a/src/services/installations.ts
+++ b/src/services/installations.ts
@@ -12,6 +12,8 @@ export async function upsertInstallation(input: {
   permissionsSnapshot: Record<string, string> | null;
   repositories: RepoInput[];
 }): Promise<void> {
+  // Use longer timeout for org-level installations with many repositories
+  // Default is 5s, but processing 50+ repos can easily exceed that
   await prisma.$transaction(async (tx) => {
     await tx.githubInstallation.upsert({
       where: { installationId: input.installationId },
@@ -65,6 +67,9 @@ export async function upsertInstallation(input: {
         }
       });
     }
+  }, {
+    maxWait: 60000, // 60 seconds - wait time for transaction to start
+    timeout: 60000  // 60 seconds - max time transaction can run
   });
 }
 
@@ -84,6 +89,7 @@ export async function upsertInstallationRepositories(input: {
   repositoriesAdded: RepoInput[];
   repositoriesRemoved: RepoInput[];
 }): Promise<void> {
+  // Use longer timeout for batch repository operations
   await prisma.$transaction(async (tx) => {
     // Ensure the installation record exists first to satisfy foreign key constraint
     await tx.githubInstallation.upsert({
@@ -129,5 +135,8 @@ export async function upsertInstallationRepositories(input: {
         data: { active: false }
       });
     }
+  }, {
+    maxWait: 60000, // 60 seconds
+    timeout: 60000  // 60 seconds
   });
 }


### PR DESCRIPTION
## Summary by Sourcery

Ensure GitHub App installation tokens are reused and explicitly passed when adding collaborators during app installation and repository addition events.

Bug Fixes:
- Fix failing collaborator invitations during app installation by generating a single installation token per webhook event and passing it through to collaborator creation to avoid Prisma transaction issues.

Enhancements:
- Introduce a helper to fetch installation tokens directly by installation ID and reuse it from repository-based token lookup and webhook handlers.

<!-- kumpeapps-issue-autoclose -->
Closes #25