### PR TITLE
[bug/#38] Fixed pending/inprogress

### DIFF
--- a/src/services/github-status.test.ts
+++ b/src/services/github-status.test.ts
@@ -217,7 +217,7 @@ describe("updateCommitStatus", () => {
         return makeJsonResponse(200, { total_count: 0, check_runs: [] });
       }
 
-      if (method === "POST" && url.includes("/commits/deadbeef123/check-runs")) {
+      if (method === "POST" && url.includes("/repos/kumpeapps/repo/check-runs")) {
         return makeJsonResponse(201, { id: 789 });
       }
 
@@ -236,7 +236,7 @@ describe("updateCommitStatus", () => {
 
     assert.equal(calls.length, 2);
     const url = String(calls[1].input);
-    assert.ok(url.includes("/repos/kumpeapps/repo/commits/deadbeef123/check-runs"));
+    assert.ok(url.includes("/repos/kumpeapps/repo/check-runs"));
 
     const body = JSON.parse(String(calls[1].init?.body ?? "{}")) as {
       name?: string;
@@ -267,7 +267,7 @@ describe("updateCommitStatus", () => {
         return makeJsonResponse(200, { total_count: 0, check_runs: [] });
       }
 
-      if (method === "POST" && url.includes("/commits/abc123/check-runs")) {
+      if (method === "POST" && url.includes("/repos/kumpeapps/repo/check-runs")) {
         return makeJsonResponse(201, { id: 456 });
       }
 
@@ -302,7 +302,7 @@ describe("updateCommitStatus", () => {
         return makeJsonResponse(200, { total_count: 0, check_runs: [] });
       }
 
-      if (method === "POST" && url.includes("/commits/abc123/check-runs")) {
+      if (method === "POST" && url.includes("/repos/kumpeapps/repo/check-runs")) {
         return makeJsonResponse(201, { id: 999 });
       }
 

--- a/src/services/github-status.ts
+++ b/src/services/github-status.ts
@@ -450,9 +450,10 @@ export async function updateCommitStatus(input: {
   const description = input.description?.slice(0, 140);
 
   // Prefer Check Runs so GitHub can display real in-progress state.
-  const checkRunPath = `/repos/${encodeURIComponent(input.repositoryOwner)}/${encodeURIComponent(input.repositoryName)}/commits/${input.commitSha}/check-runs`;
+  const checkRunListPath = `/repos/${encodeURIComponent(input.repositoryOwner)}/${encodeURIComponent(input.repositoryName)}/commits/${input.commitSha}/check-runs`;
+  const checkRunCreatePath = `/repos/${encodeURIComponent(input.repositoryOwner)}/${encodeURIComponent(input.repositoryName)}/check-runs`;
   const existingRuns = await githubGet<GithubCheckRunsResponse>(
-    checkRunPath,
+    checkRunListPath,
     input.repositoryOwner,
     input.repositoryName
   );
@@ -482,7 +483,7 @@ export async function updateCommitStatus(input: {
           return;
         }
       } else {
-        const created = await githubPost(checkRunPath, {
+        const created = await githubPost(checkRunCreatePath, {
           name: input.context,
           head_sha: input.commitSha,
           status,
@@ -519,7 +520,7 @@ export async function updateCommitStatus(input: {
           return;
         }
       } else {
-        const created = await githubPost(checkRunPath, {
+        const created = await githubPost(checkRunCreatePath, {
           name: input.context,
           head_sha: input.commitSha,
           status: "completed",


### PR DESCRIPTION
## Summary by Sourcery

Fix GitHub commit status updates to use the correct check run API endpoints for listing and creating runs so pending/in-progress states are reported properly.

Bug Fixes:
- Correct the GitHub Check Runs creation endpoint to target the repository-level check-runs API instead of a commit-specific path, ensuring statuses can be created and updated successfully.

Tests:
- Update GitHub status service tests to assert against the corrected Check Runs endpoint and request behavior.

<!-- kumpeapps-issue-autoclose -->
Closes #38