### PR TITLE
[bug/#38] added ghcr and docker auth

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -132,6 +132,7 @@ For more details, see [README-ACTION.md](../README-ACTION.md).
 | `docker_compose` | Compose file path or inline content | See below |
 | `caddy` | Caddy config file paths or inline content | See Caddy section |
 | `env_mappings` | Map env vars to GitHub repository secrets | `DATABASE_URL: DB_SECRET_NAME` |
+| `registry_auth` | Optional registry credentials for private images (GHCR/Docker Hub) | See Registry Auth section |
 | `deploy_rules` | Branch/tag rules to trigger deployment | See deploy_rules section |
 
 ### Optional Fields
@@ -176,6 +177,33 @@ docker_compose: |
       environment:
         POSTGRES_PASSWORD: $DB_PASSWORD
 ```
+
+### Registry Auth (Private Images)
+
+If your compose file pulls private images (for example from GHCR or private Docker Hub repos), configure registry credentials using `registry_auth`.
+
+Credentials are sourced from environment variables, so each `username_env` / `password_env` must be present in `env_mappings` and synced as repository secrets.
+
+```yaml
+env_mappings:
+  GHCR_USERNAME: GHCR_USERNAME
+  GHCR_TOKEN: GHCR_TOKEN
+  DOCKERHUB_USERNAME: DOCKERHUB_USERNAME
+  DOCKERHUB_TOKEN: DOCKERHUB_TOKEN
+
+registry_auth:
+  - registry: ghcr.io
+    username_env: GHCR_USERNAME
+    password_env: GHCR_TOKEN
+  - registry: https://index.docker.io/v1/
+    username_env: DOCKERHUB_USERNAME
+    password_env: DOCKERHUB_TOKEN
+```
+
+Notes:
+- Use a PAT/token for `password_env` when your registry requires tokens.
+- For GHCR, use a GitHub username + token pair with package read access.
+- The bot generates a VM-local Docker auth config and uses it for `docker compose pull` and `docker compose up`.
 
 **Automatic Managed Nebula Client Injection**
 

--- a/src/schemas/deployment-config.test.ts
+++ b/src/schemas/deployment-config.test.ts
@@ -144,6 +144,31 @@ describe("DeploymentConfigSchema", () => {
     };
     assert.ok(!DeploymentConfigSchema.safeParse(raw).success);
   });
+
+  it("parses optional registry_auth config", () => {
+    const raw = {
+      deployment_type: "docker",
+      assigned_username: "alice",
+      vm_hostname: "vm.example.com",
+      domains: ["app.example.com"],
+      docker_compose: "version: '3'",
+      env_mappings: {
+        GHCR_USERNAME: "GHCR_USERNAME",
+        GHCR_TOKEN: "GHCR_TOKEN"
+      },
+      registry_auth: [
+        {
+          registry: "ghcr.io",
+          username_env: "GHCR_USERNAME",
+          password_env: "GHCR_TOKEN"
+        }
+      ],
+      deploy_rules: [{ environment: "dev", branches: { include: [], exclude: [] } }]
+    };
+
+    const result = DeploymentConfigSchema.safeParse(raw);
+    assert.ok(result.success, JSON.stringify(result));
+  });
 });
 
 describe("validateDeploymentPolicy", () => {

--- a/src/schemas/deployment-config.ts
+++ b/src/schemas/deployment-config.ts
@@ -2,6 +2,12 @@ import { z } from "zod";
 
 const DeployEnvironmentSchema = z.enum(["dev", "stage", "prod"]);
 
+const RegistryAuthSchema = z.object({
+  registry: z.string().min(1),
+  username_env: z.string().min(1),
+  password_env: z.string().min(1)
+});
+
 export const DeployRulesSchema = z.object({
   environment: DeployEnvironmentSchema,
   branches: z.object({
@@ -23,6 +29,7 @@ export const DeploymentConfigSchema = z.object({
   domains: z.array(z.string().min(1).max(255)).min(1),
   docker_compose: z.string().min(1),
   env_mappings: z.record(z.string().min(1), z.string().min(1)),
+  registry_auth: z.array(RegistryAuthSchema).optional(),
   deploy_rules: z.array(DeployRulesSchema).min(1),
   ssh_port: z.number().int().positive().optional(), // Optional SSH port override for VM
   caddy_ssh_port: z.number().int().positive().optional(), // Optional SSH port override for Caddy server

--- a/src/services/deployment-runner.ts
+++ b/src/services/deployment-runner.ts
@@ -44,6 +44,12 @@ export type ExecuteDeploymentInput = {
   dryRunOnlyGuard: boolean;
 };
 
+type ResolvedRegistryAuth = {
+  registry: string;
+  username: string;
+  password: string;
+};
+
 async function createStep(deploymentId: number, stepName: string): Promise<number> {
   const step = await prisma.deploymentStep.create({
     data: {
@@ -784,6 +790,26 @@ export async function executeDeployment(input: ExecuteDeploymentInput): Promise<
       deploymentId: deployment.id
     });
 
+    const registryLogins: ResolvedRegistryAuth[] = [];
+    for (const auth of input.config.registry_auth ?? []) {
+      const username = resolvedSecrets.envValues[auth.username_env];
+      const password = resolvedSecrets.envValues[auth.password_env];
+
+      if (!input.dryRun && (!username || !password)) {
+        throw new Error(
+          `Missing registry_auth credentials for ${auth.registry}: expected env values ${auth.username_env} and ${auth.password_env}`
+        );
+      }
+
+      if (username && password) {
+        registryLogins.push({
+          registry: auth.registry,
+          username,
+          password
+        });
+      }
+    }
+
     console.log(`[Deployment Runner] Starting docker compose deployment to VM...`);
 
     // Resolve docker-compose content (inline or file reference)
@@ -807,6 +833,7 @@ export async function executeDeployment(input: ExecuteDeploymentInput): Promise<
           vmIp: vmIp!,
           composeConfig: dockerComposeContent,
           envValues: resolvedSecrets.envValues,
+          registryLogins,
           dryRun: input.dryRun,
           sshUser: appConfig.VM_SSH_USER,
           sshKeyPath: appConfig.VM_SSH_KEY_PATH,

--- a/src/services/ssh-deployer.ts
+++ b/src/services/ssh-deployer.ts
@@ -11,6 +11,11 @@ export type VmDeployInput = {
   vmIp: string;
   composeConfig: string;
   envValues: Record<string, string>;
+  registryLogins?: Array<{
+    registry: string;
+    username: string;
+    password: string;
+  }>;
   dryRun: boolean;
   sshUser: string;
   sshKeyPath: string;
@@ -62,6 +67,23 @@ function envFileContent(envValues: Record<string, string>): string {
   return Object.entries(envValues)
     .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
     .join("\n");
+}
+
+function dockerConfigContent(registryLogins: Array<{ registry: string; username: string; password: string }>): string {
+  const auths: Record<string, { auth: string }> = {};
+
+  for (const login of registryLogins) {
+    const key = login.registry.trim();
+    if (!key) {
+      continue;
+    }
+
+    auths[key] = {
+      auth: Buffer.from(`${login.username}:${login.password}`, "utf8").toString("base64")
+    };
+  }
+
+  return JSON.stringify({ auths });
 }
 
 function commonSshArgs(input: { sshKeyPath: string; sshPort: number }): string[] {
@@ -166,10 +188,15 @@ export async function deployComposeToVm(input: VmDeployInput): Promise<string> {
   const composePath = join(workDir, "docker-compose.yml");
   const envPath = join(workDir, ".env");
   const remoteDir = input.remoteBaseDir;
+  const dockerConfigPath = join(workDir, "docker-config.json");
+  const hasRegistryLogins = (input.registryLogins?.length ?? 0) > 0;
 
   try {
     await writeFile(composePath, input.composeConfig, "utf8");
     await writeFile(envPath, envFileContent(input.envValues), "utf8");
+    if (hasRegistryLogins && input.registryLogins) {
+      await writeFile(dockerConfigPath, dockerConfigContent(input.registryLogins), "utf8");
+    }
 
     await runRemoteSsh(
       {
@@ -218,6 +245,31 @@ export async function deployComposeToVm(input: VmDeployInput): Promise<string> {
       `${remoteDir}/.env`
     );
 
+    if (hasRegistryLogins) {
+      await runRemoteSsh(
+        {
+          sshUser: input.sshUser,
+          sshKeyPath: input.sshKeyPath,
+          sshPort: input.sshPort,
+          host: input.vmIp
+        },
+        `mkdir -p ${remoteDir}/.docker`
+      );
+
+      await copyToRemote(
+        {
+          sshUser: input.sshUser,
+          sshKeyPath: input.sshKeyPath,
+          sshPort: input.sshPort,
+          host: input.vmIp
+        },
+        dockerConfigPath,
+        `${remoteDir}/.docker/config.json`
+      );
+    }
+
+    const dockerConfigPrefix = hasRegistryLogins ? `DOCKER_CONFIG=${shellQuote(`${remoteDir}/.docker`)} ` : "";
+
     const { stdout } = await runRemoteSsh(
       {
         sshUser: input.sshUser,
@@ -225,7 +277,7 @@ export async function deployComposeToVm(input: VmDeployInput): Promise<string> {
         sshPort: input.sshPort,
         host: input.vmIp
       },
-      `cd ${remoteDir} && docker compose pull && docker compose up -d`
+      `cd ${remoteDir} && ${dockerConfigPrefix}docker compose pull && ${dockerConfigPrefix}docker compose up -d`
     );
 
     // Enable or restart the systemctl service

--- a/templates/deployment-config-template.yml
+++ b/templates/deployment-config-template.yml
@@ -99,6 +99,20 @@ env_mappings: {}
   # DATABASE_URL: DB_CONNECTION_STRING
   # API_KEY: API_SECRET_KEY
 
+# Optional: Docker/registry authentication for private images
+# Each entry points to environment variables from env_mappings.
+# These credentials are written to a VM-local Docker config and used for
+# docker compose pull/up during deployment.
+# registry_auth:
+#   # GHCR example
+#   - registry: ghcr.io
+#     username_env: GHCR_USERNAME
+#     password_env: GHCR_TOKEN
+#   # Docker Hub example
+#   - registry: https://index.docker.io/v1/
+#     username_env: DOCKERHUB_USERNAME
+#     password_env: DOCKERHUB_TOKEN
+
 # Deployment rules: when to deploy based on git branches
 # Note: This config file's environment is determined by its folder location:
 #   .kumpeapps-deploy-bot/dev/    → dev environment


### PR DESCRIPTION
## Summary by Sourcery

Add support for authenticated pulls of private container images during VM deployments using registry credentials defined in deployment configs.

New Features:
- Allow deployment configurations to specify optional registry_auth entries for container registries used by docker compose deployments.
- Generate and upload a Docker auth config to the target VM and use it for docker compose pull and up when registry credentials are provided.

Enhancements:
- Extend deployment schema, template, and docs to document and validate optional registry authentication settings.
- Validate presence of required secret-mapped environment variables for registry credentials before executing non-dry-run deployments.

Tests:
- Add a schema test to ensure deployment configs with optional registry_auth are accepted.

<!-- kumpeapps-issue-autoclose -->
Closes #38