### PR TITLE
[bug/#38] fixed

### DIFF
--- a/src/services/github-status.test.ts
+++ b/src/services/github-status.test.ts
@@ -7,7 +7,8 @@ import {
   githubApiHealthStats,
   githubApiPrometheusMetrics,
   updateGithubDeploymentStatus,
-  updateCommitStatus
+  updateCommitStatus,
+  waitForWorkflowsToComplete
 } from "./github-status.js";
 
 type FetchCall = {
@@ -289,6 +290,51 @@ describe("updateCommitStatus", () => {
     assert.equal(body.status, "in_progress");
   });
 
+  it("creates a new check run when latest matching run is completed", async () => {
+    appConfig.GITHUB_COMMIT_STATUS_ENABLED = true;
+
+    const calls: FetchCall[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ input, init });
+      const method = String(init?.method ?? "GET").toUpperCase();
+      const url = String(input);
+
+      if (method === "GET" && url.includes("/commits/abc123/check-runs")) {
+        return makeJsonResponse(200, {
+          total_count: 1,
+          check_runs: [
+            {
+              id: 321,
+              name: "kumpeapps-bot/deployment/dev",
+              status: "completed",
+              conclusion: "failure"
+            }
+          ]
+        });
+      }
+
+      if (method === "POST" && url.includes("/repos/kumpeapps/repo/check-runs")) {
+        return makeJsonResponse(201, { id: 654 });
+      }
+
+      return makeJsonResponse(404, { message: "unexpected request" });
+    }) as typeof fetch;
+
+    await updateCommitStatus({
+      repositoryOwner: "kumpeapps",
+      repositoryName: "repo",
+      commitSha: "abc123",
+      state: "pending",
+      context: "kumpeapps-bot/deployment/dev",
+      description: "Deploying to dev"
+    });
+
+    assert.equal(calls.length, 2);
+    const method = String(calls[1].init?.method ?? "GET").toUpperCase();
+    assert.equal(method, "POST");
+    assert.ok(String(calls[1].input).includes("/repos/kumpeapps/repo/check-runs"));
+  });
+
   it("truncates description to 140 characters", async () => {
     appConfig.GITHUB_COMMIT_STATUS_ENABLED = true;
 
@@ -325,6 +371,72 @@ describe("updateCommitStatus", () => {
       };
     };
     assert.equal(body.output?.summary?.length, 140);
+  });
+});
+
+describe("waitForWorkflowsToComplete", () => {
+  it("ignores deployment bot self-checks", async () => {
+    appConfig.GITHUB_WORKFLOW_CHECK_ENABLED = true;
+    appConfig.GITHUB_WORKFLOW_CHECK_TIMEOUT_MS = 1_000;
+    appConfig.GITHUB_WORKFLOW_CHECK_POLL_INTERVAL_MS = 1;
+
+    globalThis.fetch = (async () =>
+      makeJsonResponse(200, {
+        total_count: 1,
+        check_runs: [
+          {
+            id: 1,
+            name: "kumpeapps-bot/deployment/dev",
+            status: "in_progress",
+            conclusion: null
+          }
+        ]
+      })) as typeof fetch;
+
+    const result = await waitForWorkflowsToComplete({
+      repositoryOwner: "kumpeapps",
+      repositoryName: "repo",
+      commitSha: "abc123"
+    });
+
+    assert.equal(result.totalRuns, 0);
+    assert.equal(result.successful, 0);
+    assert.equal(result.failed, 0);
+  });
+
+  it("waits only on external checks and ignores self-checks", async () => {
+    appConfig.GITHUB_WORKFLOW_CHECK_ENABLED = true;
+    appConfig.GITHUB_WORKFLOW_CHECK_TIMEOUT_MS = 1_000;
+    appConfig.GITHUB_WORKFLOW_CHECK_POLL_INTERVAL_MS = 1;
+
+    globalThis.fetch = (async () =>
+      makeJsonResponse(200, {
+        total_count: 2,
+        check_runs: [
+          {
+            id: 10,
+            name: "Publish backend image",
+            status: "completed",
+            conclusion: "success"
+          },
+          {
+            id: 11,
+            name: "kumpeapps-bot/deployment/dev",
+            status: "in_progress",
+            conclusion: null
+          }
+        ]
+      })) as typeof fetch;
+
+    const result = await waitForWorkflowsToComplete({
+      repositoryOwner: "kumpeapps",
+      repositoryName: "repo",
+      commitSha: "def456"
+    });
+
+    assert.equal(result.totalRuns, 1);
+    assert.equal(result.successful, 1);
+    assert.equal(result.failed, 0);
   });
 });
 

--- a/src/services/github-status.ts
+++ b/src/services/github-status.ts
@@ -467,7 +467,7 @@ export async function updateCommitStatus(input: {
     if (input.state === "pending" || input.state === "in_progress") {
       const status = input.state === "in_progress" ? "in_progress" : "queued";
 
-      if (existingRun) {
+      if (existingRun && existingRun.status !== "completed") {
         const updatePath = `/repos/${encodeURIComponent(input.repositoryOwner)}/${encodeURIComponent(input.repositoryName)}/check-runs/${existingRun.id}`;
         const updated = await githubPatch(updatePath, {
           name: input.context,
@@ -482,27 +482,27 @@ export async function updateCommitStatus(input: {
         if (updated) {
           return;
         }
-      } else {
-        const created = await githubPost(checkRunCreatePath, {
-          name: input.context,
-          head_sha: input.commitSha,
-          status,
-          details_url: input.targetUrl,
-          output: {
-            title: input.context,
-            summary: description ?? `Deployment ${input.state.replace("_", " ")}`
-          }
-        }, input.repositoryOwner, input.repositoryName);
+      }
 
-        if (created) {
-          return;
+      const created = await githubPost(checkRunCreatePath, {
+        name: input.context,
+        head_sha: input.commitSha,
+        status,
+        details_url: input.targetUrl,
+        output: {
+          title: input.context,
+          summary: description ?? `Deployment ${input.state.replace("_", " ")}`
         }
+      }, input.repositoryOwner, input.repositoryName);
+
+      if (created) {
+        return;
       }
     } else {
       const conclusion = input.state === "success" ? "success" : "failure";
       const now = new Date().toISOString();
 
-      if (existingRun) {
+      if (existingRun && existingRun.status !== "completed") {
         const updatePath = `/repos/${encodeURIComponent(input.repositoryOwner)}/${encodeURIComponent(input.repositoryName)}/check-runs/${existingRun.id}`;
         const updated = await githubPatch(updatePath, {
           name: input.context,
@@ -519,23 +519,23 @@ export async function updateCommitStatus(input: {
         if (updated) {
           return;
         }
-      } else {
-        const created = await githubPost(checkRunCreatePath, {
-          name: input.context,
-          head_sha: input.commitSha,
-          status: "completed",
-          conclusion,
-          completed_at: now,
-          details_url: input.targetUrl,
-          output: {
-            title: input.context,
-            summary: description ?? "Deployment completed"
-          }
-        }, input.repositoryOwner, input.repositoryName);
+      }
 
-        if (created) {
-          return;
+      const created = await githubPost(checkRunCreatePath, {
+        name: input.context,
+        head_sha: input.commitSha,
+        status: "completed",
+        conclusion,
+        completed_at: now,
+        details_url: input.targetUrl,
+        output: {
+          title: input.context,
+          summary: description ?? "Deployment completed"
         }
+      }, input.repositoryOwner, input.repositoryName);
+
+      if (created) {
+        return;
       }
     }
   }
@@ -635,14 +635,17 @@ export async function waitForWorkflowsToComplete(input: {
       throw new Error("Failed to fetch workflow runs from GitHub API");
     }
 
-    const totalRuns = data.total_count;
+    // Ignore deployment bot checks to avoid waiting on our own status updates.
+    const checkRuns = data.check_runs.filter(
+      (run) => !run.name.startsWith("kumpeapps-bot/deployment/")
+    );
+    const totalRuns = checkRuns.length;
 
     if (totalRuns === 0) {
       console.log(`[GitHub Workflows] No workflows found for commit ${input.commitSha.slice(0, 7)}, proceeding`);
       return { totalRuns: 0, successful: 0, failed: 0 };
     }
 
-    const checkRuns = data.check_runs;
     const inProgress = checkRuns.filter(run => run.status !== "completed");
     const completed = checkRuns.filter(run => run.status === "completed");
     const successful = completed.filter(run => run.conclusion === "success" || run.conclusion === "skipped");


### PR DESCRIPTION
<!-- kumpeapps-issue-autoclose -->
Closes #38

## Summary by Sourcery

Handle GitHub deployment check runs more robustly and refine workflow waiting behavior.

Bug Fixes:
- Ensure new GitHub check runs are created when the latest matching run is already completed.
- Exclude deployment bot self-check runs from workflow completion waiting logic.

Enhancements:
- Always attempt to create a new GitHub check run if updating an existing non-completed run fails.
- Add tests covering check-run creation behavior and workflow waiting logic around deployment bot checks.

Tests:
- Add unit tests for creating new check runs when the latest is completed and for ignoring deployment bot checks when waiting for workflows.