### PR TITLE
[bug/#48] Fixed docker build

### DIFF
--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -90,7 +90,7 @@ export async function registerWebhookRoutes(
   const receiveWebhook = webhooks.receive.bind(webhooks) as (input: {
     id: string;
     name: string;
-    payload: string;
+    payload: unknown;
   }) => Promise<void>;
   
   // Store webhook processor for backfill support


### PR DESCRIPTION
<!-- kumpeapps-issue-autoclose -->
Closes #48

## Summary by Sourcery

Bug Fixes:
- Allow webhook receiver to handle non-string payloads without type errors.