### PR TITLE
[bug/#53] Align action with 1Password Environment sync workflow

### DIFF
--- a/README-ACTION.md
+++ b/README-ACTION.md
@@ -68,14 +68,24 @@ Go to Actions → Sync Secrets → Run workflow
 
 **Why do I need to list secrets in the workflow?**
 
-<<<<<<< HEAD
 GitHub Actions security prevents dynamic secret access (e.g., `${{ secrets[varName] }}`). The action syncs everything you pass:
-- 📤 Syncs ALL secrets passed as environment variables
+- 📤 Syncs ALL secrets passed as environment variables (or loaded from 1Password)
 - 🎯 Each deployment config uses what it needs via `env_mappings`
 - 🔄 One workflow serves all environments
-=======
-GitHub Actions security prevents dynamic secret access (e.g., `${{ secrets[varName] }}`). The action syncs whatever secrets you explicitly pass in `env`.
->>>>>>> 33daf68 ([bug/#16] Fixed Sync Secrets logic)
+
+### Optional: 1Password Environment
+
+When both `OP_SERVICE_ACCOUNT_TOKEN` and `OP_ENVIRONMENT_ID` are set in the step `env`, the action installs the 1Password CLI (latest-beta), runs `op environment read`, and syncs every variable from that Environment. If either value is missing, 1Password load is skipped and sync continues with any other env vars you passed.
+
+```yaml
+- uses: kumpeapps/kumpeapps-deployment-bot@v1
+  env:
+    KUMPEAPPS_DEPLOY_BOT_TOKEN: ${{ secrets.KUMPEAPPS_DEPLOY_BOT_TOKEN }}
+    OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+    OP_ENVIRONMENT_ID: ${{ secrets.OP_ENVIRONMENT_ID }}
+```
+
+Requires 1Password CLI 2.33.0-beta.02+ (installed automatically when enabled).
 
 ## Configuration
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'KumpeApps Deployment Bot - Sync Secrets'
-description: 'Automatically sync repository secrets to the deployment bot'
+description: 'Automatically sync repository secrets to the deployment bot (optionally loads all variables from a 1Password Environment)'
 author: 'KumpeApps'
 branding:
   icon: 'upload-cloud'
@@ -18,6 +18,73 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Skip 1Password Environment load
+      if: ${{ env.OP_SERVICE_ACCOUNT_TOKEN == '' || env.OP_ENVIRONMENT_ID == '' }}
+      shell: bash
+      run: |
+        echo "ℹ️ Skipping 1Password sync (set OP_SERVICE_ACCOUNT_TOKEN and OP_ENVIRONMENT_ID in the step env to enable)"
+
+    - name: Install 1Password CLI
+      if: ${{ env.OP_SERVICE_ACCOUNT_TOKEN != '' && env.OP_ENVIRONMENT_ID != '' }}
+      uses: 1password/install-cli-action@v4
+      with:
+        version: latest-beta
+
+    - name: Load all variables from 1Password Environment
+      if: ${{ env.OP_SERVICE_ACCOUNT_TOKEN != '' && env.OP_ENVIRONMENT_ID != '' }}
+      shell: bash
+      env:
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ env.OP_SERVICE_ACCOUNT_TOKEN }}
+        OP_ENVIRONMENT_ID: ${{ env.OP_ENVIRONMENT_ID }}
+      run: |
+        set -euo pipefail
+
+        mask_value() {
+          local value="$1"
+          while IFS= read -r line || [ -n "$line" ]; do
+            if [ -n "$line" ]; then
+              echo "::add-mask::${line}"
+            fi
+          done <<< "$value"
+        }
+
+        write_env_var() {
+          local name="$1"
+          local value="$2"
+          mask_value "$value"
+          {
+            echo "${name}<<EOF"
+            printf '%s' "$value"
+            echo
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+        }
+
+        op_stderr="$(mktemp)"
+        if ! env_output="$(op environment read "$OP_ENVIRONMENT_ID" 2>"$op_stderr")"; then
+          echo "::error::Failed to read 1Password environment: $(tr -d '\n' < "$op_stderr")"
+          rm -f "$op_stderr"
+          exit 1
+        fi
+        rm -f "$op_stderr"
+
+        loaded_count=0
+        while IFS= read -r line || [ -n "$line" ]; do
+          [ -z "$line" ] && continue
+          name="${line%%=*}"
+          value="${line#*=}"
+          value="$(printf '%s' "$value" | tr -d '\r\n')"
+          if [ -z "$name" ]; then
+            continue
+          fi
+          write_env_var "$name" "$value"
+          loaded_count=$((loaded_count + 1))
+          echo "🔐 Loaded 1Password variable: ${name}"
+        done <<< "$env_output"
+        unset env_output
+
+        echo "✅ Loaded ${loaded_count} variable(s) from 1Password Environment"
+
     - name: Sync all secrets to deployment bot
       shell: bash
       env:
@@ -43,10 +110,10 @@ runs:
         echo ""
         
         # Get all environment variables, excluding system/GitHub Actions variables
-        SECRET_NAMES=$(env | grep -E '^[A-Z][A-Z0-9_]*=' | cut -d= -f1 | grep -v -E '^(GITHUB_|RUNNER_|CI|PATH|HOME|USER|SHELL|PWD|OLDPWD|LANG|LC_|TERM|SHLVL|_|BOT_URL|BOT_TOKEN|ACTIONS_|AGENT_|ANDROID_|AZURE_|CHROME|CONDA|DEPLOYMENT_|DOTNET_|GOROOT|GRADLE_|GRAALVM_|HOMEBREW_|ImageOS|ImageVersion|INVOCATION_ID|JAVA_|JOURNAL_STREAM|LEIN_|NVM_|PERFLOG_|POWERSHELL_|SELENIUM_|SGX_|STATS_|SWIFT_|VCPKG_|INPUT_)')
+        SECRET_NAMES=$(env | grep -E '^[A-Z][A-Z0-9_]*=' | cut -d= -f1 | grep -v -E '^(GITHUB_|RUNNER_|CI|PATH|HOME|USER|SHELL|PWD|OLDPWD|LANG|LC_|TERM|SHLVL|_|BOT_URL|BOT_TOKEN|OP_SERVICE_ACCOUNT_TOKEN|OP_ENVIRONMENT_ID|KUMPEAPPS_DEPLOY_BOT_TOKEN|DEPLOYMENT_BOT_TOKEN|ACTIONS_|AGENT_|ANDROID_|AZURE_|CHROME|CONDA|DEPLOYMENT_|DOTNET_|GOROOT|GRADLE_|GRAALVM_|HOMEBREW_|ImageOS|ImageVersion|INVOCATION_ID|JAVA_|JOURNAL_STREAM|LEIN_|NVM_|PERFLOG_|POWERSHELL_|SELENIUM_|SGX_|STATS_|SWIFT_|VCPKG_|INPUT_)')
         if [ -z "$SECRET_NAMES" ]; then
           echo "::warning::No secrets found in environment variables to sync"
-          echo "::warning::Make sure to pass your secrets in the env section of the action"
+          echo "::warning::Configure 1Password Environment secrets and/or pass secrets via the step env"
           exit 0
         fi
         

--- a/docs/examples/repo-sync-secrets-simple.yml
+++ b/docs/examples/repo-sync-secrets-simple.yml
@@ -6,6 +6,8 @@ name: Sync Secrets to Deployment Bot
 #
 # Behavior:
 # - ALL secrets passed in the env section are synced to the bot
+# - Optional: set OP_SERVICE_ACCOUNT_TOKEN and OP_ENVIRONMENT_ID to load every
+#   variable from a 1Password Environment automatically (no per-secret list needed)
 # - You don't need to maintain a list of which secrets each config needs
 # - The bot will use the appropriate secrets based on each deployment config's env_mappings
 #
@@ -31,6 +33,10 @@ jobs:
         env:
           # Bot token (auto-created when GitHub App is installed)
           KUMPEAPPS_DEPLOY_BOT_TOKEN: ${{ secrets.KUMPEAPPS_DEPLOY_BOT_TOKEN }}
+          
+          # Optional: load all variables from a 1Password Environment
+          # OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          # OP_ENVIRONMENT_ID: ${{ secrets.OP_ENVIRONMENT_ID }}
           
           # All your application secrets - just pass them all here.
           # The action syncs everything you pass, and each deployment config

--- a/src/services/workflow-generator.ts
+++ b/src/services/workflow-generator.ts
@@ -40,6 +40,8 @@ export function generateSyncSecretsWorkflow(managedNebulaEnabled: boolean): stri
 #
 # Behavior:
 # - ALL secrets passed in the env section are synced to the bot
+# - Optional: set OP_SERVICE_ACCOUNT_TOKEN and OP_ENVIRONMENT_ID to load every
+#   variable from a 1Password Environment automatically (no per-secret list needed)
 # - You don't need to maintain a list of which secrets each config needs
 # - The bot will use the appropriate secrets based on each deployment config's env_mappings
 #
@@ -66,7 +68,11 @@ jobs:
           # Bot token (auto-created when GitHub App is installed)
           KUMPEAPPS_DEPLOY_BOT_TOKEN: \${{ secrets.KUMPEAPPS_DEPLOY_BOT_TOKEN }}
           
-          # All your application secrets - just pass them all here.
+          # Optional: load all variables from a 1Password Environment
+          # OP_SERVICE_ACCOUNT_TOKEN: \${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          # OP_ENVIRONMENT_ID: \${{ secrets.OP_ENVIRONMENT_ID }}
+          
+          # All your application secrets - just pass them here.
           # The action syncs everything you pass, and each deployment config
           # will use only the secrets it needs via its env_mappings section.
           


### PR DESCRIPTION
## Summary by Sourcery

Integrate optional 1Password Environment sync into the deployment bot secrets action and update documentation/examples to describe the new workflow.

Enhancements:
- Add conditional 1Password CLI installation and environment variable loading to the sync-secrets GitHub Action.
- Exclude 1Password and deployment bot-related env vars from being treated as secrets during sync.
- Clarify action behavior and configuration in README and generated workflows to cover 1Password Environment usage.

Documentation:
- Document optional 1Password Environment support in README and usage examples, including required CLI version and example configuration.

<!-- kumpeapps-issue-autoclose -->
Closes #53