### PR TITLE
[bug/#56] Fixed Bug and added ai agent skills

### DIFF
--- a/.codacy/cli.sh
+++ b/.codacy/cli.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+
+set -e +o pipefail
+
+# Set up paths first
+bin_name="codacy-cli-v2"
+
+# Determine OS-specific paths
+os_name=$(uname)
+arch=$(uname -m)
+
+case "$arch" in
+"x86_64")
+  arch="amd64"
+  ;;
+"x86")
+  arch="386"
+  ;;
+"aarch64"|"arm64")
+  arch="arm64"
+  ;;
+esac
+
+if [ -z "$CODACY_CLI_V2_TMP_FOLDER" ]; then
+    if [ "$(uname)" = "Linux" ]; then
+        CODACY_CLI_V2_TMP_FOLDER="$HOME/.cache/codacy/codacy-cli-v2"
+    elif [ "$(uname)" = "Darwin" ]; then
+        CODACY_CLI_V2_TMP_FOLDER="$HOME/Library/Caches/Codacy/codacy-cli-v2"
+    else
+        CODACY_CLI_V2_TMP_FOLDER=".codacy-cli-v2"
+    fi
+fi
+
+version_file="$CODACY_CLI_V2_TMP_FOLDER/version.yaml"
+
+
+get_version_from_yaml() {
+    if [ -f "$version_file" ]; then
+        local version=$(grep -o 'version: *"[^"]*"' "$version_file" | cut -d'"' -f2)
+        if [ -n "$version" ]; then
+            echo "$version"
+            return 0
+        fi
+    fi
+    return 1
+}
+
+get_latest_version() {
+    local response
+    if [ -n "$GH_TOKEN" ]; then
+        response=$(curl -Lq --header "Authorization: Bearer $GH_TOKEN" "https://api.github.com/repos/codacy/codacy-cli-v2/releases/latest" 2>/dev/null)
+    else
+        response=$(curl -Lq "https://api.github.com/repos/codacy/codacy-cli-v2/releases/latest" 2>/dev/null)
+    fi
+
+    handle_rate_limit "$response"
+    local version=$(echo "$response" | grep -m 1 tag_name | cut -d'"' -f4)
+    echo "$version"
+}
+
+handle_rate_limit() {
+    local response="$1"
+    if echo "$response" | grep -q "API rate limit exceeded"; then
+          fatal "Error: GitHub API rate limit exceeded. Please try again later"
+    fi
+}
+
+download_file() {
+    local url="$1"
+
+    echo "Downloading from URL: ${url}"
+    if command -v curl > /dev/null 2>&1; then
+        curl -# -LS "$url" -O
+    elif command -v wget > /dev/null 2>&1; then
+        wget "$url"
+    else
+        fatal "Error: Could not find curl or wget, please install one."
+    fi
+}
+
+download() {
+    local url="$1"
+    local output_folder="$2"
+
+    ( cd "$output_folder" && download_file "$url" )
+}
+
+download_cli() {
+    # OS name lower case
+    suffix=$(echo "$os_name" | tr '[:upper:]' '[:lower:]')
+
+    local bin_folder="$1"
+    local bin_path="$2"
+    local version="$3"
+
+    if [ ! -f "$bin_path" ]; then
+        echo "📥 Downloading CLI version $version..."
+
+        remote_file="codacy-cli-v2_${version}_${suffix}_${arch}.tar.gz"
+        url="https://github.com/codacy/codacy-cli-v2/releases/download/${version}/${remote_file}"
+
+        download "$url" "$bin_folder"
+        tar xzfv "${bin_folder}/${remote_file}" -C "${bin_folder}"
+    fi
+}
+
+# Warn if CODACY_CLI_V2_VERSION is set and update is requested
+if [ -n "$CODACY_CLI_V2_VERSION" ] && [ "$1" = "update" ]; then
+    echo "⚠️  Warning: Performing update with forced version $CODACY_CLI_V2_VERSION"
+    echo "    Unset CODACY_CLI_V2_VERSION to use the latest version"
+fi
+
+# Ensure version.yaml exists and is up to date
+if [ ! -f "$version_file" ] || [ "$1" = "update" ]; then
+    echo "ℹ️  Fetching latest version..."
+    version=$(get_latest_version)
+    mkdir -p "$CODACY_CLI_V2_TMP_FOLDER"
+    echo "version: \"$version\"" > "$version_file"
+fi
+
+# Set the version to use
+if [ -n "$CODACY_CLI_V2_VERSION" ]; then
+    version="$CODACY_CLI_V2_VERSION"
+else
+    version=$(get_version_from_yaml)
+fi
+
+
+# Set up version-specific paths
+bin_folder="${CODACY_CLI_V2_TMP_FOLDER}/${version}"
+
+mkdir -p "$bin_folder"
+bin_path="$bin_folder"/"$bin_name"
+
+# Download the tool if not already installed
+download_cli "$bin_folder" "$bin_path" "$version"
+chmod +x "$bin_path"
+
+run_command="$bin_path"
+if [ -z "$run_command" ]; then
+    fatal "Codacy cli v2 binary could not be found."
+fi
+
+if [ "$#" -eq 1 ] && [ "$1" = "download" ]; then
+    echo "Codacy cli v2 download succeeded"
+else
+    eval "$run_command $*"
+fi

--- a/.codacy/codacy.yaml
+++ b/.codacy/codacy.yaml
@@ -1,0 +1,15 @@
+runtimes:
+    - dart@3.7.2
+    - go@1.24.13
+    - java@17.0.10
+    - node@22.2.0
+    - python@3.11.11
+tools:
+    - dartanalyzer@3.7.2
+    - eslint@8.57.0
+    - lizard@1.17.31
+    - opengrep@1.16.4
+    - pmd@7.11.0
+    - pylint@3.3.6
+    - revive@1.7.0
+    - trivy@0.69.3

--- a/.cursor/rules/00-coding-standards.mdc
+++ b/.cursor/rules/00-coding-standards.mdc
@@ -1,0 +1,1 @@
+/Users/justinkumpe/Developer/kumpeapps-deployment-bot/.ai-agent-skills/rules/00-coding-standards.mdc

--- a/.cursor/rules/10-stack-defaults.mdc
+++ b/.cursor/rules/10-stack-defaults.mdc
@@ -1,0 +1,1 @@
+/Users/justinkumpe/Developer/kumpeapps-deployment-bot/.ai-agent-skills/rules/10-stack-defaults.mdc

--- a/.cursor/rules/20-python-fastapi.mdc
+++ b/.cursor/rules/20-python-fastapi.mdc
@@ -1,0 +1,1 @@
+/Users/justinkumpe/Developer/kumpeapps-deployment-bot/.ai-agent-skills/rules/20-python-fastapi.mdc

--- a/.cursor/rules/30-angular.mdc
+++ b/.cursor/rules/30-angular.mdc
@@ -1,0 +1,1 @@
+/Users/justinkumpe/Developer/kumpeapps-deployment-bot/.ai-agent-skills/rules/30-angular.mdc

--- a/.cursor/rules/40-docker-testing.mdc
+++ b/.cursor/rules/40-docker-testing.mdc
@@ -1,0 +1,1 @@
+/Users/justinkumpe/Developer/kumpeapps-deployment-bot/.ai-agent-skills/rules/40-docker-testing.mdc

--- a/.cursor/rules/50-auth-oidc.mdc
+++ b/.cursor/rules/50-auth-oidc.mdc
@@ -1,0 +1,1 @@
+/Users/justinkumpe/Developer/kumpeapps-deployment-bot/.ai-agent-skills/rules/50-auth-oidc.mdc

--- a/.cursor/skills/angular-frontend
+++ b/.cursor/skills/angular-frontend
@@ -1,0 +1,1 @@
+/Users/justinkumpe/Developer/kumpeapps-deployment-bot/.ai-agent-skills/skills/angular-frontend

--- a/.cursor/skills/code-review
+++ b/.cursor/skills/code-review
@@ -1,0 +1,1 @@
+/Users/justinkumpe/Developer/kumpeapps-deployment-bot/.ai-agent-skills/skills/code-review

--- a/.cursor/skills/dependency-versions
+++ b/.cursor/skills/dependency-versions
@@ -1,0 +1,1 @@
+/Users/justinkumpe/Developer/kumpeapps-deployment-bot/.ai-agent-skills/skills/dependency-versions

--- a/.cursor/skills/devcontainer-venv
+++ b/.cursor/skills/devcontainer-venv
@@ -1,0 +1,1 @@
+/Users/justinkumpe/Developer/kumpeapps-deployment-bot/.ai-agent-skills/skills/devcontainer-venv

--- a/.cursor/skills/docker-multi-container
+++ b/.cursor/skills/docker-multi-container
@@ -1,0 +1,1 @@
+/Users/justinkumpe/Developer/kumpeapps-deployment-bot/.ai-agent-skills/skills/docker-multi-container

--- a/.cursor/skills/kumpeapps-deploy
+++ b/.cursor/skills/kumpeapps-deploy
@@ -1,0 +1,1 @@
+/Users/justinkumpe/Developer/kumpeapps-deployment-bot/.ai-agent-skills/skills/kumpeapps-deploy

--- a/.cursor/skills/oidc-oauth-auth
+++ b/.cursor/skills/oidc-oauth-auth
@@ -1,0 +1,1 @@
+/Users/justinkumpe/Developer/kumpeapps-deployment-bot/.ai-agent-skills/skills/oidc-oauth-auth

--- a/.cursor/skills/python-fastapi
+++ b/.cursor/skills/python-fastapi
@@ -1,0 +1,1 @@
+/Users/justinkumpe/Developer/kumpeapps-deployment-bot/.ai-agent-skills/skills/python-fastapi

--- a/.cursor/skills/python-style
+++ b/.cursor/skills/python-style
@@ -1,0 +1,1 @@
+/Users/justinkumpe/Developer/kumpeapps-deployment-bot/.ai-agent-skills/skills/python-style

--- a/.cursor/skills/solid-dry
+++ b/.cursor/skills/solid-dry
@@ -1,0 +1,1 @@
+/Users/justinkumpe/Developer/kumpeapps-deployment-bot/.ai-agent-skills/skills/solid-dry

--- a/.cursor/skills/sqlalchemy-db
+++ b/.cursor/skills/sqlalchemy-db
@@ -1,0 +1,1 @@
+/Users/justinkumpe/Developer/kumpeapps-deployment-bot/.ai-agent-skills/skills/sqlalchemy-db

--- a/.cursor/skills/tdd-workflow
+++ b/.cursor/skills/tdd-workflow
@@ -1,0 +1,1 @@
+/Users/justinkumpe/Developer/kumpeapps-deployment-bot/.ai-agent-skills/skills/tdd-workflow

--- a/.cursor/skills/testing-mariadb
+++ b/.cursor/skills/testing-mariadb
@@ -1,0 +1,1 @@
+/Users/justinkumpe/Developer/kumpeapps-deployment-bot/.ai-agent-skills/skills/testing-mariadb

--- a/.env.example
+++ b/.env.example
@@ -64,7 +64,21 @@ VM_SSH_KEY_PATH=/root/.ssh/id_rsa
 VM_SSH_PORT=22
 VM_DEPLOY_BASE_DIR=/opt/kumpeapps
 SSH_CONNECT_TIMEOUT_SECONDS=15
+# Fail only after this many seconds with no progress (screen gone / log idle).
 SSH_DOCKER_COMMAND_TIMEOUT_SECONDS=600
+# Keep waiting up to this long while the deploy screen session is still alive (large image pulls).
+SSH_DOCKER_DEPLOY_MAX_SECONDS=3600
+# Private-LAN pull-through caches on the bot host (VMs reach these without Nebula).
+# DOCKER_HUB_MIRROR_URL=http://10.0.0.5:5000
+# DOCKER_GHCR_MIRROR_URL=http://10.0.0.5:5001
+DOCKER_HUB_MIRROR_URL=
+DOCKER_GHCR_MIRROR_URL=
+DOCKER_REGISTRY_CACHE_TTL=24h
+# Bot-default registry creds (used by caches + default VM DOCKER_CONFIG; per-app registry_auth overrides).
+DOCKERHUB_USERNAME=
+DOCKERHUB_TOKEN=
+GHCR_USERNAME=
+GHCR_TOKEN=
 SSH_COMMAND_RETRIES=2
 SSH_ALERT_FINAL_FAILURES_1H_HIGH=10
 SSH_ALERT_TIMEOUT_FAILURES_1H_HIGH=3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".ai-agent-skills"]
+	path = .ai-agent-skills
+	url = https://github.com/kumpeapps/ai-agent-skills.git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,5 +66,43 @@ services:
       retries: 10
     restart: unless-stopped
 
+  # Docker Hub pull-through cache (VM registry-mirrors → this). Auth uses bot DOCKERHUB_* creds.
+  docker-hub-cache:
+    image: registry:2
+    container_name: kumpeapps-docker-hub-cache
+    environment:
+      REGISTRY_PROXY_REMOTEURL: https://registry-1.docker.io
+      REGISTRY_PROXY_USERNAME: ${DOCKERHUB_USERNAME:-}
+      REGISTRY_PROXY_PASSWORD: ${DOCKERHUB_TOKEN:-}
+      REGISTRY_PROXY_TTL: ${DOCKER_REGISTRY_CACHE_TTL:-24h}
+      REGISTRY_STORAGE_DELETE_ENABLED: "true"
+    ports:
+      - "5000:5000"
+    volumes:
+      - docker_hub_cache_data:/var/lib/registry
+    restart: unless-stopped
+    profiles:
+      - registry-cache
+
+  # GHCR pull-through cache (compose ghcr.io refs rewritten → this). Auth uses bot GHCR_* creds.
+  docker-ghcr-cache:
+    image: registry:2
+    container_name: kumpeapps-docker-ghcr-cache
+    environment:
+      REGISTRY_PROXY_REMOTEURL: https://ghcr.io
+      REGISTRY_PROXY_USERNAME: ${GHCR_USERNAME:-}
+      REGISTRY_PROXY_PASSWORD: ${GHCR_TOKEN:-}
+      REGISTRY_PROXY_TTL: ${DOCKER_REGISTRY_CACHE_TTL:-24h}
+      REGISTRY_STORAGE_DELETE_ENABLED: "true"
+    ports:
+      - "5001:5000"
+    volumes:
+      - docker_ghcr_cache_data:/var/lib/registry
+    restart: unless-stopped
+    profiles:
+      - registry-cache
+
 volumes:
   mariadb_data:
+  docker_hub_cache_data:
+  docker_ghcr_cache_data:

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -157,6 +157,27 @@ Primary incident paths covered:
 3. Record timeline, root cause, and follow-up tasks.
 4. Link incident notes in the next release notes under known risks/resolved issues.
 
+## Docker Hub / GHCR pull-through caches
+
+Private-LAN caches on the bot host cut Hub 429s and WAN bandwidth. VMs reach them without Nebula.
+
+**Important:** Docker Hub pull-through does **not** work with direct pulls like `BOT:5000/library/busybox` (returns `not found`). Hub must be configured as daemon `registry-mirrors`. GHCR uses compose image rewrite to `BOT:5001/...`.
+
+1. Set bot `.env`:
+   - `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` (cache upstream + default VM auth)
+   - `GHCR_USERNAME` / `GHCR_TOKEN` (`read:packages`)
+   - `DOCKER_HUB_MIRROR_URL=http://<bot-private-ip>:5000`
+   - `DOCKER_GHCR_MIRROR_URL=http://<bot-private-ip>:5001`
+   - `DOCKER_REGISTRY_CACHE_TTL=24h`
+2. Start caches on the bot host (`docker-hub-cache` / `docker-ghcr-cache`). Ensure Hub/GHCR tokens are set on that host so the proxies can pull upstream.
+3. Firewall: allow VM subnet → bot `:5000` and `:5001` only.
+4. **New VMs:** Virtualizor recipe [`scripts/virtualizor-recipes/configure-docker-registry-caches.sh`](../scripts/virtualizor-recipes/configure-docker-registry-caches.sh) (edit `BOT_CACHE_IP` at top; no args). Sets:
+   - `registry-mirrors: ["http://BOT:5000"]` (Hub)
+   - `insecure-registries: ["BOT:5000", "BOT:5001"]` (HTTP)
+5. **Existing VMs:** run that recipe once as root, or leave as-is — bot falls back to direct Hub/GHCR pulls (no deploy failure).
+6. On deploy: Hub images stay as `busybox:1.36` (daemon mirrors them). `ghcr.io/...` is rewritten to `BOT:5001/...` when insecure-registries allows it.
+7. Per-app `registry_auth` overrides bot defaults; GHCR override skips rewrite for that deploy.
+
 ## Game-day Simulation Checklist
 
 1. [x] Simulate queue depth breach and verify runbook path execution.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -204,6 +204,7 @@ Notes:
 - Use a PAT/token for `password_env` when your registry requires tokens.
 - For GHCR, use a GitHub username + token pair with package read access.
 - The bot generates a VM-local Docker auth config and uses it for `docker compose pull` and `docker compose up`.
+- Operators can set bot-wide `DOCKERHUB_*` / `GHCR_*` defaults (and optional LAN pull-through caches). Per-app `registry_auth` overrides those defaults for that deploy only. See the operator runbook for mirror setup.
 
 **Automatic Managed Nebula Client Injection**
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "node dist/index.js",
     "smoke:test": "bash scripts/smoke-test.sh",
     "release:notes": "bash scripts/generate-release-notes.sh",
-    "test": "node --import tsx/esm --test-reporter spec --test src/schemas/deployment-config.test.ts src/services/deploy-rules.test.ts src/services/secret-crypto-core.test.ts src/services/secret-health.test.ts src/services/ssh-health.test.ts src/services/webhook-security-health.test.ts src/services/virtualizor-health.test.ts src/services/admin-api-security-health.test.ts src/services/admin-auth.test.ts src/services/admin-auth.routes.test.ts src/services/rate-limit-health.test.ts src/services/deployment-compensation-health.test.ts src/services/github-status.test.ts src/services/rate-limit.test.ts",
+    "test": "node --import tsx/esm --test-reporter spec --test src/schemas/deployment-config.test.ts src/services/deploy-rules.test.ts src/services/secret-crypto-core.test.ts src/services/secret-health.test.ts src/services/ssh-health.test.ts src/services/ssh-deployer.test.ts src/services/webhook-security-health.test.ts src/services/virtualizor-health.test.ts src/services/admin-api-security-health.test.ts src/services/admin-auth.test.ts src/services/admin-auth.routes.test.ts src/services/rate-limit-health.test.ts src/services/deployment-compensation-health.test.ts src/services/github-status.test.ts src/services/rate-limit.test.ts",
     "test:docker": "docker compose --profile test run --rm bot-test",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",

--- a/scripts/virtualizor-recipes/configure-docker-registry-caches.sh
+++ b/scripts/virtualizor-recipes/configure-docker-registry-caches.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Virtualizor Recipe: Configure Docker Hub registry-mirrors + insecure-registries
+# for KumpeApps pull-through caches on the bot host.
+#
+# Runs automatically as root on new VMs (no arguments required).
+# Edit BOT_CACHE_IP below before installing this recipe in Virtualizor.
+#
+# Hub images (busybox, etc.) use registry-mirrors — do NOT pull host:5000/library/...
+# GHCR images are rewritten by the bot to BOT:5001/... and need insecure-registries.
+#
+# Safe to re-run on existing VMs.
+
+set -euo pipefail
+
+# --- edit once when installing the recipe in Virtualizor ---
+BOT_CACHE_IP="172.16.20.11"
+HUB_CACHE_PORT="5000"
+GHCR_CACHE_PORT="5001"
+DAEMON_JSON="/etc/docker/daemon.json"
+# -----------------------------------------------------------
+
+if [[ -z "${BOT_CACHE_IP}" || "${BOT_CACHE_IP}" == "CHANGE_ME" ]]; then
+  echo "ERROR: set BOT_CACHE_IP at the top of this recipe script" >&2
+  exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "ERROR: docker is not installed on this VM" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "ERROR: python3 is required to merge daemon.json" >&2
+  exit 1
+fi
+
+HUB_MIRROR_URL="http://${BOT_CACHE_IP}:${HUB_CACHE_PORT}"
+HUB_HOST="${BOT_CACHE_IP}:${HUB_CACHE_PORT}"
+GHCR_HOST="${BOT_CACHE_IP}:${GHCR_CACHE_PORT}"
+
+mkdir -p "$(dirname "${DAEMON_JSON}")"
+
+if [[ -f "${DAEMON_JSON}" ]]; then
+  EXISTING="$(cat "${DAEMON_JSON}")"
+else
+  EXISTING="{}"
+fi
+
+TMP_JSON="$(mktemp)"
+TMP_FLAG="$(mktemp)"
+trap 'rm -f "${TMP_JSON}" "${TMP_FLAG}"' EXIT
+
+EXISTING="${EXISTING}" HUB_MIRROR_URL="${HUB_MIRROR_URL}" HUB_HOST="${HUB_HOST}" GHCR_HOST="${GHCR_HOST}" \
+  python3 - "${TMP_JSON}" "${TMP_FLAG}" <<'PY'
+import json, os, sys
+
+out_json, out_flag = sys.argv[1], sys.argv[2]
+existing = os.environ["EXISTING"].strip() or "{}"
+hub_mirror = os.environ["HUB_MIRROR_URL"].rstrip("/")
+hub_host = os.environ["HUB_HOST"]
+ghcr_host = os.environ["GHCR_HOST"]
+
+try:
+    data = json.loads(existing)
+    if not isinstance(data, dict):
+        data = {}
+except Exception:
+    data = {}
+
+changed = False
+
+# Docker Hub pull-through only works as registry-mirrors (not direct host:port pulls).
+mirrors = data.get("registry-mirrors") or []
+if not isinstance(mirrors, list):
+    mirrors = []
+normalized = [str(m).rstrip("/") for m in mirrors]
+if hub_mirror not in normalized:
+    data["registry-mirrors"] = [hub_mirror]
+    changed = True
+else:
+    data["registry-mirrors"] = [str(m).rstrip("/") for m in mirrors]
+
+insecure = data.get("insecure-registries") or []
+if not isinstance(insecure, list):
+    insecure = []
+for host in (hub_host, ghcr_host):
+    if host not in insecure:
+        insecure.append(host)
+        changed = True
+data["insecure-registries"] = insecure
+
+with open(out_json, "w", encoding="utf-8") as fh:
+    fh.write(json.dumps(data, indent=2) + "\n")
+with open(out_flag, "w", encoding="utf-8") as fh:
+    fh.write("1" if changed else "0")
+PY
+
+install -m 644 "${TMP_JSON}" "${DAEMON_JSON}"
+CHANGED="$(cat "${TMP_FLAG}")"
+
+echo "Configured registry-mirrors: ${HUB_MIRROR_URL}"
+echo "Configured insecure-registries: ${HUB_HOST}, ${GHCR_HOST}"
+echo "Wrote ${DAEMON_JSON}"
+
+if [[ "${CHANGED}" == "1" ]]; then
+  echo "Restarting docker to apply daemon.json..."
+  systemctl restart docker
+else
+  echo "daemon.json already up to date; docker restart skipped"
+fi
+
+docker info --format 'Registry Mirrors: {{json .RegistryConfig.Mirrors}}' || true
+docker info --format 'Insecure registry hosts: {{range $k,$v := .RegistryConfig.IndexConfigs}}{{if not $v.Secure}}{{$k}} {{end}}{{end}}' || true
+echo "Done."

--- a/src/config.ts
+++ b/src/config.ts
@@ -95,7 +95,22 @@ const EnvSchema = z.object({
   VM_DEPLOY_BASE_DIR: z.string().default("/opt/kumpeapps"),
   DEPLOYMENT_SERVICE_NAME: z.string().default("kumpeapps-bot-deployment"),
   SSH_CONNECT_TIMEOUT_SECONDS: z.coerce.number().int().positive().default(15),
+  /** Seconds with no deploy progress (screen gone / log idle) before failing. */
   SSH_DOCKER_COMMAND_TIMEOUT_SECONDS: z.coerce.number().int().positive().default(600),
+  /** Absolute max wait while a live screen session may still be pulling large images. */
+  SSH_DOCKER_DEPLOY_MAX_SECONDS: z.coerce.number().int().positive().default(3600),
+  /** Private-LAN Docker Hub pull-through cache URL (e.g. http://10.x.x.x:5000). Empty disables. */
+  DOCKER_HUB_MIRROR_URL: z.string().default(""),
+  /** Private-LAN GHCR pull-through cache URL (e.g. http://10.x.x.x:5001). Empty disables rewrite. */
+  DOCKER_GHCR_MIRROR_URL: z.string().default(""),
+  /** Distribution proxy.ttl for Hub/GHCR caches (e.g. 24h). */
+  DOCKER_REGISTRY_CACHE_TTL: z.string().default("24h"),
+  /** Bot-default Docker Hub credentials (cache upstream + default VM DOCKER_CONFIG). */
+  DOCKERHUB_USERNAME: z.string().default(""),
+  DOCKERHUB_TOKEN: z.string().default(""),
+  /** Bot-default GHCR credentials (cache upstream + default VM DOCKER_CONFIG). */
+  GHCR_USERNAME: z.string().default(""),
+  GHCR_TOKEN: z.string().default(""),
   SSH_COMMAND_RETRIES: z.coerce.number().int().nonnegative().max(5).default(2),
   SSH_ALERT_FINAL_FAILURES_1H_HIGH: z.coerce.number().int().nonnegative().default(10),
   SSH_ALERT_TIMEOUT_FAILURES_1H_HIGH: z.coerce.number().int().nonnegative().default(3),

--- a/src/services/deployment-runner.ts
+++ b/src/services/deployment-runner.ts
@@ -9,7 +9,7 @@ import {
   validateDeploymentPolicy,
   validateCaddyfileDomains
 } from "../schemas/deployment-config.js";
-import { compensateComposeOnVm, deployCaddyConfig, deployComposeToVm } from "./ssh-deployer.js";
+import { compensateComposeOnVm, deployCaddyConfig, deployComposeToVm, probeVmDockerRegistryConfig } from "./ssh-deployer.js";
 import { resolveRepositoryEnvValues } from "./repository-secrets.js";
 import { ensureVirtualizorVm, resolvePlanDetails } from "./virtualizor.js";
 import { createGithubDeployment, updateGithubDeploymentStatus, updateCommitStatus, checkWorkflowsOnce, reportDeploymentError, closeDeploymentErrorIssue } from "./github-status.js";
@@ -19,6 +19,14 @@ import { getGitHubToken } from "./github-app-auth.js";
 import { syncAuthorizedAdminsToVm } from "./vm-user-management.js";
 import { fetchFileFromGitHub } from "./github-automation.js";
 import { getNebulaIpAddress } from "./nebula-provisioning.js";
+import {
+  isHubRegistryMirrorConfigured,
+  isMirrorHostAllowed,
+  mergeRegistryLogins,
+  mirrorUrlToHostPort,
+  rewriteGhcrImageRefs,
+  shouldSkipGhcrRewrite
+} from "./docker-registry-mirror.js";
 
 /**
  * Thrown when required GitHub Actions workflows are still in progress.
@@ -832,7 +840,7 @@ export async function executeDeployment(input: ExecuteDeploymentInput): Promise<
       deploymentId: deployment.id
     });
 
-    const registryLogins: ResolvedRegistryAuth[] = [];
+    const deployOverrides: ResolvedRegistryAuth[] = [];
     for (const auth of input.config.registry_auth ?? []) {
       const username = resolvedSecrets.envValues[auth.username_env];
       const password = resolvedSecrets.envValues[auth.password_env];
@@ -844,13 +852,31 @@ export async function executeDeployment(input: ExecuteDeploymentInput): Promise<
       }
 
       if (username && password) {
-        registryLogins.push({
+        deployOverrides.push({
           registry: auth.registry,
           username,
           password
         });
       }
     }
+
+    const botDefaults: ResolvedRegistryAuth[] = [];
+    if (appConfig.DOCKERHUB_USERNAME && appConfig.DOCKERHUB_TOKEN) {
+      botDefaults.push({
+        registry: "https://index.docker.io/v1/",
+        username: appConfig.DOCKERHUB_USERNAME,
+        password: appConfig.DOCKERHUB_TOKEN
+      });
+    }
+    if (appConfig.GHCR_USERNAME && appConfig.GHCR_TOKEN) {
+      botDefaults.push({
+        registry: "ghcr.io",
+        username: appConfig.GHCR_USERNAME,
+        password: appConfig.GHCR_TOKEN
+      });
+    }
+
+    const registryLogins = mergeRegistryLogins({ botDefaults, deployOverrides });
 
     console.log(`[Deployment Runner] Starting docker compose deployment to VM...`);
 
@@ -865,6 +891,59 @@ export async function executeDeployment(input: ExecuteDeploymentInput): Promise<
 
     // Inject Managed Nebula client service
     dockerComposeContent = await injectNebulaClient(dockerComposeContent);
+
+    const hubMirrorUrl = appConfig.DOCKER_HUB_MIRROR_URL.trim() || undefined;
+    const ghcrMirrorUrl = appConfig.DOCKER_GHCR_MIRROR_URL.trim() || undefined;
+
+    let insecureHosts = new Set<string>();
+    let registryMirrors: string[] = [];
+    if ((hubMirrorUrl || ghcrMirrorUrl) && !input.dryRun) {
+      const probed = await probeVmDockerRegistryConfig({
+        vmIp: vmIp!,
+        sshUser: appConfig.VM_SSH_USER,
+        sshKeyPath: appConfig.VM_SSH_KEY_PATH,
+        sshPort: input.config.ssh_port ?? appConfig.VM_SSH_PORT
+      });
+      insecureHosts = probed.insecureHosts;
+      registryMirrors = probed.registryMirrors;
+      console.log(
+        `[Deployment Runner] VM insecure registries: ${
+          insecureHosts.size ? [...insecureHosts].join(",") : "(none)"
+        }; registry-mirrors: ${registryMirrors.length ? registryMirrors.join(",") : "(none)"}`
+      );
+    }
+
+    // Hub pull-through only works via daemon registry-mirrors (recipe sets this).
+    // Do NOT rewrite Hub images to host:5000/... — direct pulls return "not found".
+    if (hubMirrorUrl) {
+      if (isHubRegistryMirrorConfigured(hubMirrorUrl, registryMirrors)) {
+        console.log(
+          `[Deployment Runner] Hub pulls will use registry-mirrors ${hubMirrorUrl} (busybox etc. unchanged in compose)`
+        );
+      } else {
+        console.log(
+          `[Deployment Runner] Hub registry-mirrors not configured on VM — pulling Docker Hub directly (fallback)`
+        );
+      }
+    }
+
+    const ghcrMirrorAllowed = Boolean(ghcrMirrorUrl && isMirrorHostAllowed(ghcrMirrorUrl, insecureHosts));
+
+    if (ghcrMirrorUrl && !shouldSkipGhcrRewrite(registryLogins) && ghcrMirrorAllowed) {
+      const rewritten = rewriteGhcrImageRefs(dockerComposeContent, mirrorUrlToHostPort(ghcrMirrorUrl));
+      dockerComposeContent = rewritten.content;
+      console.log(
+        `[Deployment Runner] Rewrote ${rewritten.rewrittenCount} ghcr.io image ref(s) to ${mirrorUrlToHostPort(ghcrMirrorUrl)}`
+      );
+    } else if (ghcrMirrorUrl && shouldSkipGhcrRewrite(registryLogins)) {
+      console.log(
+        `[Deployment Runner] Skipping GHCR mirror rewrite — deploy registry_auth overrides ghcr.io`
+      );
+    } else if (ghcrMirrorUrl && !ghcrMirrorAllowed) {
+      console.log(
+        `[Deployment Runner] Skipping GHCR mirror rewrite — ${mirrorUrlToHostPort(ghcrMirrorUrl)} not in VM insecure-registries (pulling ghcr.io directly)`
+      );
+    }
 
     await runStep(
       deployment.id,

--- a/src/services/docker-registry-auth.ts
+++ b/src/services/docker-registry-auth.ts
@@ -1,0 +1,63 @@
+/**
+ * Docker registry auth helpers for VM docker config.json generation.
+ */
+
+/** Registries that Docker treats as Docker Hub and expects under this config key. */
+const DOCKER_HUB_CONFIG_KEY = "https://index.docker.io/v1/";
+
+const DOCKER_HUB_ALIASES = new Set([
+  "docker.io",
+  "index.docker.io",
+  "registry-1.docker.io",
+  "https://index.docker.io/v1",
+  "https://index.docker.io/v1/",
+  "https://registry-1.docker.io",
+  "https://registry-1.docker.io/v2/"
+]);
+
+/**
+ * Normalize a registry hostname/URL to the key Docker looks up in config.json.
+ * Docker Hub pulls only use auth when the key is exactly https://index.docker.io/v1/.
+ */
+export function normalizeDockerRegistryKey(registry: string): string {
+  const trimmed = registry.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+
+  const withoutTrailingSlash = trimmed.replace(/\/+$/, "");
+  const lower = withoutTrailingSlash.toLowerCase();
+
+  if (DOCKER_HUB_ALIASES.has(lower) || DOCKER_HUB_ALIASES.has(`${lower}/`)) {
+    return DOCKER_HUB_CONFIG_KEY;
+  }
+
+  // Strip scheme for non-Hub registries so ghcr.io and https://ghcr.io both work.
+  const host = lower.replace(/^https?:\/\//, "").split("/")[0] ?? lower;
+  if (DOCKER_HUB_ALIASES.has(host)) {
+    return DOCKER_HUB_CONFIG_KEY;
+  }
+
+  return host || trimmed;
+}
+
+export function buildDockerConfigContent(
+  registryLogins: Array<{ registry: string; username: string; password: string }>
+): string {
+  const auths: Record<string, { auth: string }> = {};
+
+  for (const login of registryLogins) {
+    const key = normalizeDockerRegistryKey(login.registry);
+    if (!key) {
+      continue;
+    }
+
+    auths[key] = {
+      auth: Buffer.from(`${login.username}:${login.password}`, "utf8").toString("base64")
+    };
+  }
+
+  return JSON.stringify({ auths });
+}
+
+export { DOCKER_HUB_CONFIG_KEY };

--- a/src/services/docker-registry-mirror.test.ts
+++ b/src/services/docker-registry-mirror.test.ts
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  DOCKER_HUB_CONFIG_KEY,
+  mergeRegistryLogins,
+  mirrorUrlToHostPort,
+  mergeDockerDaemonJson,
+  rewriteGhcrImageRefs,
+  rewriteHubImageRefs,
+  shouldSkipGhcrRewrite,
+  shouldSkipHubRewrite,
+  insecureRegistryHostsFromDockerInfo,
+  isMirrorHostAllowed,
+  isHubRegistryMirrorConfigured,
+  registryMirrorsFromDockerInfo
+} from "./docker-registry-mirror.js";
+
+describe("mirrorUrlToHostPort", () => {
+  it("strips scheme and trailing slash", () => {
+    assert.equal(mirrorUrlToHostPort("http://10.0.0.5:5001/"), "10.0.0.5:5001");
+    assert.equal(mirrorUrlToHostPort("https://registry.example.com:443"), "registry.example.com:443");
+  });
+});
+
+describe("mergeDockerDaemonJson", () => {
+  it("adds Hub registry-mirrors and insecure-registries for HTTP mirrors", () => {
+    const { content, changed } = mergeDockerDaemonJson({
+      existingJson: "{}",
+      hubMirrorUrl: "http://10.0.0.5:5000",
+      ghcrMirrorUrl: "http://10.0.0.5:5001"
+    });
+    const parsed = JSON.parse(content);
+    assert.equal(changed, true);
+    assert.deepEqual(parsed["registry-mirrors"], ["http://10.0.0.5:5000"]);
+    assert.ok(parsed["insecure-registries"].includes("10.0.0.5:5000"));
+    assert.ok(parsed["insecure-registries"].includes("10.0.0.5:5001"));
+  });
+
+  it("is idempotent when mirrors already configured", () => {
+    const first = mergeDockerDaemonJson({
+      existingJson: "{}",
+      hubMirrorUrl: "http://10.0.0.5:5000",
+      ghcrMirrorUrl: "http://10.0.0.5:5001"
+    });
+    const second = mergeDockerDaemonJson({
+      existingJson: first.content,
+      hubMirrorUrl: "http://10.0.0.5:5000",
+      ghcrMirrorUrl: "http://10.0.0.5:5001"
+    });
+    assert.equal(second.changed, false);
+    assert.equal(second.content, first.content);
+  });
+
+  it("preserves unrelated daemon.json keys", () => {
+    const { content } = mergeDockerDaemonJson({
+      existingJson: JSON.stringify({ "log-driver": "json-file", "registry-mirrors": ["http://old:5000"] }),
+      hubMirrorUrl: "http://10.0.0.5:5000"
+    });
+    const parsed = JSON.parse(content);
+    assert.equal(parsed["log-driver"], "json-file");
+    assert.deepEqual(parsed["registry-mirrors"], ["http://10.0.0.5:5000"]);
+  });
+});
+
+describe("rewriteGhcrImageRefs", () => {
+  it("rewrites ghcr.io image refs to the mirror host:port", () => {
+    const input = `
+services:
+  api:
+    image: ghcr.io/kumpedns/kumpedns-backend:latest
+  nebula_client:
+    image: ghcr.io/kumpeapps/managed-nebula/client:kumpeapps
+`;
+    const { content, rewrittenCount } = rewriteGhcrImageRefs(input, "10.0.0.5:5001");
+    assert.equal(rewrittenCount, 2);
+    assert.match(content, /image:\s*10\.0\.0\.5:5001\/kumpedns\/kumpedns-backend:latest/);
+    assert.match(content, /image:\s*10\.0\.0\.5:5001\/kumpeapps\/managed-nebula\/client:kumpeapps/);
+    assert.equal(content.includes("ghcr.io/"), false);
+  });
+
+  it("leaves non-ghcr images untouched", () => {
+    const input = "services:\n  db:\n    image: busybox:1.36\n";
+    const { content, rewrittenCount } = rewriteGhcrImageRefs(input, "10.0.0.5:5001");
+    assert.equal(rewrittenCount, 0);
+    assert.match(content, /busybox:1\.36/);
+  });
+});
+
+describe("rewriteHubImageRefs", () => {
+  it("rewrites official and namespaced Hub images through the Hub cache", () => {
+    const input = `
+services:
+  init:
+    image: busybox:1.36
+  app:
+    image: myuser/myapp:1.2.3
+  explicit:
+    image: docker.io/library/nginx:alpine
+`;
+    const { content, rewrittenCount } = rewriteHubImageRefs(input, "10.0.0.5:5000");
+    assert.equal(rewrittenCount, 3);
+    assert.match(content, /image:\s*10\.0\.0\.5:5000\/library\/busybox:1\.36/);
+    assert.match(content, /image:\s*10\.0\.0\.5:5000\/myuser\/myapp:1\.2\.3/);
+    assert.match(content, /image:\s*10\.0\.0\.5:5000\/library\/nginx:alpine/);
+  });
+
+  it("does not rewrite ghcr or already-mirrored host:port images", () => {
+    const input = `
+services:
+  a:
+    image: ghcr.io/org/img:latest
+  b:
+    image: 10.0.0.5:5001/org/img:latest
+  c:
+    image: quay.io/org/img:latest
+`;
+    const { content, rewrittenCount } = rewriteHubImageRefs(input, "10.0.0.5:5000");
+    assert.equal(rewrittenCount, 0);
+    assert.match(content, /ghcr\.io\/org\/img:latest/);
+    assert.match(content, /10\.0\.0\.5:5001\/org\/img:latest/);
+    assert.match(content, /quay\.io\/org\/img:latest/);
+  });
+});
+
+describe("mergeRegistryLogins", () => {
+  it("uses bot defaults then lets deploy overrides win per registry", () => {
+    const merged = mergeRegistryLogins({
+      botDefaults: [
+        { registry: "docker.io", username: "bot-hub", password: "hub-token" },
+        { registry: "ghcr.io", username: "bot-ghcr", password: "ghcr-token" }
+      ],
+      deployOverrides: [{ registry: "ghcr.io", username: "app", password: "app-token" }]
+    });
+    const byKey = Object.fromEntries(merged.map((l) => [l.registry, l]));
+    assert.equal(byKey[DOCKER_HUB_CONFIG_KEY]?.username, "bot-hub");
+    assert.equal(byKey["ghcr.io"]?.username, "app");
+    assert.equal(byKey["ghcr.io"]?.password, "app-token");
+  });
+
+  it("reports which registries were overridden by deploy config", () => {
+    const result = mergeRegistryLogins({
+      botDefaults: [{ registry: "ghcr.io", username: "bot", password: "b" }],
+      deployOverrides: [{ registry: "https://ghcr.io", username: "app", password: "a" }]
+    });
+    assert.ok(result.some((l) => l.registry === "ghcr.io" && l.overridden));
+  });
+});
+
+describe("shouldSkipGhcrRewrite", () => {
+  it("is true only when ghcr.io was overridden by deploy config", () => {
+    assert.equal(
+      shouldSkipGhcrRewrite([{ registry: "ghcr.io", username: "bot", password: "b", overridden: false }]),
+      false
+    );
+    assert.equal(
+      shouldSkipGhcrRewrite([{ registry: "ghcr.io", username: "app", password: "a", overridden: true }]),
+      true
+    );
+  });
+});
+
+describe("shouldSkipHubRewrite", () => {
+  it("is true only when Docker Hub was overridden by deploy config", () => {
+    assert.equal(
+      shouldSkipHubRewrite([
+        { registry: DOCKER_HUB_CONFIG_KEY, username: "bot", password: "b", overridden: false }
+      ]),
+      false
+    );
+    assert.equal(
+      shouldSkipHubRewrite([
+        { registry: DOCKER_HUB_CONFIG_KEY, username: "app", password: "a", overridden: true }
+      ]),
+      true
+    );
+  });
+});
+
+describe("insecureRegistryHostsFromDockerInfo", () => {
+  it("collects IndexConfigs entries marked Secure=false", () => {
+    const json = JSON.stringify({
+      InsecureRegistryCIDRs: ["127.0.0.0/8"],
+      IndexConfigs: {
+        "docker.io": { Name: "docker.io", Secure: true, Official: true },
+        "10.0.0.5:5000": { Name: "10.0.0.5:5000", Secure: false, Official: false },
+        "10.0.0.5:5001": { Name: "10.0.0.5:5001", Secure: false, Official: false }
+      }
+    });
+    const hosts = insecureRegistryHostsFromDockerInfo(json);
+    assert.equal(hosts.has("10.0.0.5:5000"), true);
+    assert.equal(hosts.has("10.0.0.5:5001"), true);
+    assert.equal(hosts.has("docker.io"), false);
+  });
+
+  it("returns empty set on invalid json so rewrites are skipped safely", () => {
+    assert.equal(insecureRegistryHostsFromDockerInfo("not-json").size, 0);
+  });
+});
+
+describe("isMirrorHostAllowed", () => {
+  it("is true only when mirror host:port is in the insecure set", () => {
+    const hosts = new Set(["10.0.0.5:5000", "10.0.0.5:5001"]);
+    assert.equal(isMirrorHostAllowed("http://10.0.0.5:5000", hosts), true);
+    assert.equal(isMirrorHostAllowed("http://10.0.0.5:5001/", hosts), true);
+    assert.equal(isMirrorHostAllowed("http://10.0.0.5:5000", new Set()), false);
+  });
+});
+
+describe("isHubRegistryMirrorConfigured", () => {
+  it("matches daemon registry-mirrors entries to the Hub cache URL", () => {
+    assert.equal(
+      isHubRegistryMirrorConfigured("http://172.16.20.11:5000", ["http://172.16.20.11:5000/"]),
+      true
+    );
+    assert.equal(
+      isHubRegistryMirrorConfigured("http://172.16.20.11:5000", ["http://other:5000"]),
+      false
+    );
+    assert.equal(isHubRegistryMirrorConfigured("http://172.16.20.11:5000", []), false);
+  });
+});
+
+describe("registryMirrorsFromDockerInfo", () => {
+  it("reads Mirrors from RegistryConfig json", () => {
+    const mirrors = registryMirrorsFromDockerInfo(
+      JSON.stringify({ Mirrors: ["http://172.16.20.11:5000/"], IndexConfigs: {} })
+    );
+    assert.deepEqual(mirrors, ["http://172.16.20.11:5000/"]);
+  });
+});

--- a/src/services/docker-registry-mirror.ts
+++ b/src/services/docker-registry-mirror.ts
@@ -1,0 +1,281 @@
+/**
+ * Docker Hub / GHCR pull-through mirror helpers (compose image rewrite, auth merge).
+ * Daemon.json helpers remain for optional OS-image baking of insecure-registries only;
+ * the bot no longer writes daemon.json on VMs (deploy user lacks sudo for /etc/docker).
+ */
+
+import {
+  DOCKER_HUB_CONFIG_KEY,
+  normalizeDockerRegistryKey
+} from "./docker-registry-auth.js";
+
+export { DOCKER_HUB_CONFIG_KEY };
+
+export type RegistryLogin = {
+  registry: string;
+  username: string;
+  password: string;
+  /** True when this entry came from per-deploy registry_auth rather than bot defaults. */
+  overridden?: boolean;
+};
+
+export function mirrorUrlToHostPort(mirrorUrl: string): string {
+  return mirrorUrl
+    .trim()
+    .replace(/^https?:\/\//i, "")
+    .replace(/\/+$/, "");
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+export type MergeDockerDaemonJsonInput = {
+  existingJson: string;
+  hubMirrorUrl?: string;
+  ghcrMirrorUrl?: string;
+};
+
+/**
+ * Merge Hub registry-mirrors and HTTP insecure-registries into daemon.json.
+ * Returns changed=false when the effective config is already correct.
+ */
+export function mergeDockerDaemonJson(input: MergeDockerDaemonJsonInput): {
+  content: string;
+  changed: boolean;
+} {
+  let parsed: Record<string, unknown> = {};
+  const trimmed = input.existingJson.trim();
+  if (trimmed) {
+    try {
+      parsed = JSON.parse(trimmed) as Record<string, unknown>;
+      if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+        parsed = {};
+      }
+    } catch {
+      parsed = {};
+    }
+  }
+
+  const insecure = new Set<string>(
+    Array.isArray(parsed["insecure-registries"])
+      ? (parsed["insecure-registries"] as unknown[]).map(String)
+      : []
+  );
+
+  if (input.hubMirrorUrl) {
+    const hubUrl = input.hubMirrorUrl.replace(/\/+$/, "");
+    parsed["registry-mirrors"] = [hubUrl];
+    insecure.add(mirrorUrlToHostPort(hubUrl));
+  }
+
+  if (input.ghcrMirrorUrl) {
+    insecure.add(mirrorUrlToHostPort(input.ghcrMirrorUrl));
+  }
+
+  parsed["insecure-registries"] = uniqueStrings([...insecure]).sort();
+
+  const content = `${JSON.stringify(parsed, null, 2)}\n`;
+
+  const desired = JSON.parse(content) as Record<string, unknown>;
+  let existingObj: Record<string, unknown> = {};
+  try {
+    existingObj = trimmed ? (JSON.parse(trimmed) as Record<string, unknown>) : {};
+  } catch {
+    existingObj = {};
+  }
+
+  const sameMirrors =
+    JSON.stringify(desired["registry-mirrors"] ?? null) ===
+    JSON.stringify(existingObj["registry-mirrors"] ?? null);
+  const sameInsecure =
+    JSON.stringify([...(desired["insecure-registries"] as string[])].sort()) ===
+    JSON.stringify(
+      Array.isArray(existingObj["insecure-registries"])
+        ? [...(existingObj["insecure-registries"] as string[])].sort()
+        : []
+    );
+
+  return { content, changed: !(sameMirrors && sameInsecure) };
+}
+
+/**
+ * Rewrite ghcr.io/ORG/IMAGE refs to MIRROR/ORG/IMAGE (YAML image: lines and quoted forms).
+ */
+export function rewriteGhcrImageRefs(
+  composeYaml: string,
+  mirrorHostPort: string
+): { content: string; rewrittenCount: number } {
+  const hostPort = mirrorUrlToHostPort(mirrorHostPort);
+  let rewrittenCount = 0;
+  const content = composeYaml.replace(
+    /(image:\s*["']?)ghcr\.io\/([^\s"']+)/gi,
+    (_match, prefix: string, path: string) => {
+      rewrittenCount += 1;
+      return `${prefix}${hostPort}/${path}`;
+    }
+  );
+  return { content, rewrittenCount };
+}
+
+/**
+ * First path component is a non-Hub registry host if it contains '.' or ':' or is localhost,
+ * except docker.io which is Docker Hub and should be rewritten to the Hub cache.
+ */
+function imageRefHasNonHubRegistryHost(imageRef: string): boolean {
+  const withoutDigest = imageRef.split("@")[0] ?? imageRef;
+  const firstSlash = withoutDigest.indexOf("/");
+  const firstComponent =
+    firstSlash === -1 ? withoutDigest.split(":")[0]! : withoutDigest.slice(0, firstSlash);
+  if (firstComponent.toLowerCase() === "docker.io") {
+    return false;
+  }
+  return firstComponent.includes(".") || firstComponent.includes(":") || firstComponent === "localhost";
+}
+
+/**
+ * Map a Docker Hub image name to the pull-through cache path.
+ * Official images become library/<name>. Strips docker.io/ prefix.
+ */
+export function hubImageToCachePath(imageRef: string): string {
+  const atIdx = imageRef.indexOf("@");
+  const digestSuffix = atIdx >= 0 ? imageRef.slice(atIdx) : "";
+  const withoutDigest = atIdx >= 0 ? imageRef.slice(0, atIdx) : imageRef;
+
+  let name = withoutDigest;
+  let tagSuffix = "";
+  const colonIdx = withoutDigest.lastIndexOf(":");
+  const lastSlash = withoutDigest.lastIndexOf("/");
+  if (colonIdx > lastSlash) {
+    name = withoutDigest.slice(0, colonIdx);
+    tagSuffix = withoutDigest.slice(colonIdx);
+  }
+
+  let path = name.replace(/^docker\.io\//i, "");
+  if (!path.includes("/")) {
+    path = `library/${path}`;
+  }
+  return `${path}${tagSuffix}${digestSuffix}`;
+}
+
+/**
+ * Rewrite Docker Hub image refs (busybox, user/app, docker.io/...) to HUB_MIRROR/path.
+ * Leaves explicit non-Hub registries (ghcr.io, quay.io, host:port, …) untouched.
+ */
+export function rewriteHubImageRefs(
+  composeYaml: string,
+  mirrorHostPort: string
+): { content: string; rewrittenCount: number } {
+  const hostPort = mirrorUrlToHostPort(mirrorHostPort);
+  let rewrittenCount = 0;
+  const content = composeYaml.replace(
+    /(image:\s*["']?)([^\s"']+)/gi,
+    (match, prefix: string, imageRef: string) => {
+      if (imageRefHasNonHubRegistryHost(imageRef)) {
+        return match;
+      }
+      rewrittenCount += 1;
+      return `${prefix}${hostPort}/${hubImageToCachePath(imageRef)}`;
+    }
+  );
+  return { content, rewrittenCount };
+}
+
+export type MergeRegistryLoginsInput = {
+  botDefaults: Array<{ registry: string; username: string; password: string }>;
+  deployOverrides: Array<{ registry: string; username: string; password: string }>;
+};
+
+/**
+ * Bot-level Hub/GHCR defaults, overridden per registry by deploy registry_auth.
+ * Returned registry keys are normalized (Hub → https://index.docker.io/v1/).
+ */
+export function mergeRegistryLogins(input: MergeRegistryLoginsInput): RegistryLogin[] {
+  const byKey = new Map<string, RegistryLogin>();
+
+  for (const login of input.botDefaults) {
+    const key = normalizeDockerRegistryKey(login.registry);
+    if (!key || !login.username || !login.password) continue;
+    byKey.set(key, {
+      registry: key,
+      username: login.username,
+      password: login.password,
+      overridden: false
+    });
+  }
+
+  for (const login of input.deployOverrides) {
+    const key = normalizeDockerRegistryKey(login.registry);
+    if (!key || !login.username || !login.password) continue;
+    byKey.set(key, {
+      registry: key,
+      username: login.username,
+      password: login.password,
+      overridden: true
+    });
+  }
+
+  return [...byKey.values()];
+}
+
+/** True when deploy config overrode ghcr.io (skip LAN rewrite so override creds hit real GHCR). */
+export function shouldSkipGhcrRewrite(logins: RegistryLogin[]): boolean {
+  return logins.some((l) => l.registry === "ghcr.io" && l.overridden);
+}
+
+/** True when deploy config overrode Docker Hub (skip LAN rewrite so override creds hit real Hub). */
+export function shouldSkipHubRewrite(logins: RegistryLogin[]): boolean {
+  return logins.some((l) => l.registry === DOCKER_HUB_CONFIG_KEY && l.overridden);
+}
+
+/**
+ * Parse `docker info --format '{{json .RegistryConfig}}'` output into insecure registry hosts.
+ * Used to gate compose rewrites so existing VMs without insecure-registries keep pulling upstream.
+ */
+export function insecureRegistryHostsFromDockerInfo(registryConfigJson: string): Set<string> {
+  const hosts = new Set<string>();
+  try {
+    const cfg = JSON.parse(registryConfigJson) as {
+      IndexConfigs?: Record<string, { Secure?: boolean } | null>;
+    };
+    for (const [name, conf] of Object.entries(cfg.IndexConfigs ?? {})) {
+      if (conf && conf.Secure === false) {
+        hosts.add(name.toLowerCase());
+      }
+    }
+  } catch {
+    return hosts;
+  }
+  return hosts;
+}
+
+/** Whether a mirror URL's host:port is listed as an insecure registry on the VM. */
+export function isMirrorHostAllowed(mirrorUrl: string, insecureHosts: Set<string>): boolean {
+  if (!mirrorUrl.trim()) return false;
+  return insecureHosts.has(mirrorUrlToHostPort(mirrorUrl).toLowerCase());
+}
+
+/** Read registry-mirrors list from `docker info --format '{{json .RegistryConfig}}'`. */
+export function registryMirrorsFromDockerInfo(registryConfigJson: string): string[] {
+  try {
+    const cfg = JSON.parse(registryConfigJson) as { Mirrors?: unknown };
+    if (!Array.isArray(cfg.Mirrors)) return [];
+    return cfg.Mirrors.map(String);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Hub pull-through only works via daemon registry-mirrors (not direct host:port pulls).
+ * Compare configured mirrors to DOCKER_HUB_MIRROR_URL.
+ */
+export function isHubRegistryMirrorConfigured(hubMirrorUrl: string, mirrors: string[]): boolean {
+  if (!hubMirrorUrl.trim() || mirrors.length === 0) return false;
+  const wantHost = mirrorUrlToHostPort(hubMirrorUrl).toLowerCase();
+  const wantUrl = hubMirrorUrl.replace(/\/+$/, "").toLowerCase();
+  return mirrors.some((m) => {
+    const normalized = m.replace(/\/+$/, "").toLowerCase();
+    return normalized === wantUrl || mirrorUrlToHostPort(m).toLowerCase() === wantHost;
+  });
+}

--- a/src/services/github-issue-types.ts
+++ b/src/services/github-issue-types.ts
@@ -1,0 +1,23 @@
+/**
+ * GitHub issue type helpers (pure; no app config / network).
+ */
+
+export type GitHubIssueType = {
+  name: string;
+  is_enabled?: boolean;
+};
+
+/**
+ * Pick a preferred issue type name (default Task) when the repo/org exposes it.
+ * Returns undefined when unavailable so callers can omit `type` on create.
+ */
+export function resolvePreferredIssueTypeName(
+  availableTypes: GitHubIssueType[],
+  preferredName = "Task"
+): string | undefined {
+  const preferred = preferredName.toLowerCase();
+  const match = availableTypes.find(
+    (t) => t.name.toLowerCase() === preferred && t.is_enabled !== false
+  );
+  return match?.name;
+}

--- a/src/services/ssh-deploy-scripts.ts
+++ b/src/services/ssh-deploy-scripts.ts
@@ -1,0 +1,345 @@
+/**
+ * Pure builders for remote VM deploy shell scripts (no app config / SSH side effects).
+ */
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+/**
+ * Build the shell lines that run an operator-configured post-deploy hook.
+ * Runs only when the main compose step exits 0; hook exit code is logged but
+ * does not override the deployment result.
+ */
+function buildPostDeployHookLines(remoteLogFile: string, postDeployHook?: string): string[] {
+  if (!postDeployHook) return [];
+
+  return [
+    `if [ "$PIPE_EXIT" -eq 0 ]; then`,
+    `  echo "--- Running post-deploy hook ---" | tee -a ${shellQuote(remoteLogFile)}`,
+    `  { ${postDeployHook}; } 2>&1 | tee -a ${shellQuote(remoteLogFile)}`,
+    `  HOOK_EXIT=$?`,
+    `  if [ "$HOOK_EXIT" -ne 0 ]; then echo "Post-deploy hook exited $HOOK_EXIT" | tee -a ${shellQuote(remoteLogFile)}; fi`,
+    `fi`,
+  ];
+}
+
+/**
+ * Ensure nebula_client is running without pulling or recreating it.
+ * App deploys intentionally exclude nebula_client so a compose/env diff cannot bounce the VPN;
+ * this step only starts a stopped client (or no-ops if already running / not in compose).
+ */
+export function buildEnsureNebulaClientLines(remoteLogFile: string): string[] {
+  const log = shellQuote(remoteLogFile);
+
+  return [
+    `echo "Ensuring nebula_client is running..." | tee -a ${log}`,
+    `if docker compose config --services 2>>${log} | grep -qx 'nebula_client'; then`,
+    `  if docker compose ps --status running --services 2>>${log} | grep -qx 'nebula_client'; then`,
+    `    echo "nebula_client already running" | tee -a ${log}`,
+    `  else`,
+    `    echo "nebula_client not running — starting without recreate" | tee -a ${log}`,
+    `    { docker compose up -d --no-deps --no-recreate nebula_client; } 2>&1 | tee -a ${log}`,
+    `    NEBULA_EXIT=\${PIPESTATUS[0]}`,
+    `    if [ "$NEBULA_EXIT" -ne 0 ]; then`,
+    `      echo "ERROR: failed to start nebula_client (exit $NEBULA_EXIT)" | tee -a ${log}`,
+    `      PIPE_EXIT=$NEBULA_EXIT`,
+    `    elif ! docker compose ps --status running --services 2>>${log} | grep -qx 'nebula_client'; then`,
+    `      echo "ERROR: nebula_client is still not running after up" | tee -a ${log}`,
+    `      PIPE_EXIT=1`,
+    `    else`,
+    `      echo "nebula_client is running" | tee -a ${log}`,
+    `    fi`,
+    `  fi`,
+    `else`,
+    `  echo "nebula_client not defined in compose — skipping" | tee -a ${log}`,
+    `fi`,
+  ];
+}
+
+export type VmDeployScriptInput = {
+  remoteDir: string;
+  remoteLogFile: string;
+  remoteExitFile: string;
+  /** When set, exported as DOCKER_CONFIG for the whole script (registry auth). */
+  dockerConfigDir?: string;
+  postDeployHook?: string;
+};
+
+/**
+ * Shell lines that report whether registry auth is present and whether Docker Hub
+ * credentials actually work — without printing secrets.
+ */
+export function buildRegistryAuthDiagnosticLines(remoteLogFile: string): string[] {
+  const log = shellQuote(remoteLogFile);
+
+  return [
+    `echo "Checking registry auth..." | tee -a ${log}`,
+    `if [ -z "\${DOCKER_CONFIG:-}" ] || [ ! -f "\$DOCKER_CONFIG/config.json" ]; then`,
+    `  echo "WARNING: no Docker registry auth config on VM (anonymous pulls; Hub 429s likely)" | tee -a ${log}`,
+    `else`,
+    `  echo "DOCKER_CONFIG_FILE=\$DOCKER_CONFIG/config.json" | tee -a ${log}`,
+    // Prefer python3 (common on deploy VMs); fall back to grep for keys only.
+    `  if command -v python3 >/dev/null 2>&1; then`,
+    `    python3 - <<'PY' 2>&1 | tee -a ${log}`,
+    `import json, base64, os, ssl, urllib.error, urllib.request`,
+    `cfg_path = os.path.join(os.environ["DOCKER_CONFIG"], "config.json")`,
+    `auths = json.load(open(cfg_path)).get("auths") or {}`,
+    `keys = sorted(auths.keys())`,
+    `print("registry_auth_keys=" + (",".join(keys) if keys else "(none)"))`,
+    `hub_key = "https://index.docker.io/v1/"`,
+    `if hub_key not in auths:`,
+    `    print("WARNING: Docker Hub auth key missing — expected https://index.docker.io/v1/ (aliases like docker.io are normalized by the bot)")`,
+    `else:`,
+    `    try:`,
+    `        user_pass = base64.b64decode(auths[hub_key]["auth"]).decode("utf-8")`,
+    `        username = user_pass.split(":", 1)[0]`,
+    `        print("Docker Hub username=" + username)`,
+    `        req = urllib.request.Request(`,
+    `            "https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/busybox:pull"`,
+    `        )`,
+    `        token = base64.b64encode(user_pass.encode("utf-8")).decode("ascii")`,
+    `        req.add_header("Authorization", "Basic " + token)`,
+    `        ctx = ssl.create_default_context()`,
+    `        with urllib.request.urlopen(req, timeout=20, context=ctx) as resp:`,
+    `            data = json.load(resp)`,
+    `        if data.get("token") or data.get("access_token"):`,
+    `            print("Docker Hub login OK")`,
+    `        else:`,
+    `            print("Docker Hub login FAILED: token response missing token")`,
+    `    except urllib.error.HTTPError as exc:`,
+    `        print(f"Docker Hub login FAILED: HTTP {exc.code}")`,
+    `    except Exception as exc:`,
+    `        print(f"Docker Hub login FAILED: {exc}")`,
+    `PY`,
+    `  else`,
+    `    echo "registry_auth_keys=$(grep -oE '"[^"]+": \\{[^}]*"auth"' "\$DOCKER_CONFIG/config.json" | sed 's/": {.*"auth//' | tr -d '"' | paste -sd, - || echo '(parse failed)')" | tee -a ${log}`,
+    `    if grep -q 'https://index.docker.io/v1/' "\$DOCKER_CONFIG/config.json"; then`,
+    `      echo "Docker Hub auth key present (python3 unavailable — could not verify login)" | tee -a ${log}`,
+    `    else`,
+    `      echo "WARNING: Docker Hub auth key missing — expected https://index.docker.io/v1/" | tee -a ${log}`,
+    `    fi`,
+    `  fi`,
+    `fi`,
+  ];
+}
+
+/**
+ * Build the remote bash script that runs inside a detached screen session.
+ * Exports DOCKER_CONFIG once (never as a bare assignment after `timeout`), keeps a
+ * persistent `.deploy-latest.log`, and retries compose pull with backoff for Hub 429s.
+ */
+export function buildVmDeployScript(input: VmDeployScriptInput): string {
+  const log = shellQuote(input.remoteLogFile);
+  const exitFile = shellQuote(input.remoteExitFile);
+  const dir = shellQuote(input.remoteDir);
+  const latestLog = shellQuote(`${input.remoteDir}/.deploy-latest.log`);
+  const postDeployHookLines = buildPostDeployHookLines(input.remoteLogFile, input.postDeployHook);
+  const ensureNebulaLines = buildEnsureNebulaClientLines(input.remoteLogFile);
+  const registryAuthDiagLines = buildRegistryAuthDiagnosticLines(input.remoteLogFile);
+
+  const dockerConfigExport = input.dockerConfigDir
+    ? [
+        `export DOCKER_CONFIG=${shellQuote(input.dockerConfigDir)}`,
+        `echo "DOCKER_CONFIG=$DOCKER_CONFIG" | tee -a ${log}`,
+      ]
+    : [`echo "DOCKER_CONFIG=(default)" | tee -a ${log}`];
+
+  return [
+    "#!/bin/bash",
+    "set -o pipefail",
+    // screen sessions often get a minimal PATH; ensure docker is reachable.
+    'export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH"',
+    `cd ${dir}`,
+    `rm -f ${exitFile} ${log}`,
+    "PIPE_EXIT=1",
+    `write_exit() { echo "$PIPE_EXIT" > ${exitFile}; cp -f ${log} ${latestLog} 2>/dev/null || true; }`,
+    "trap write_exit EXIT",
+    `echo "=== deploy started $(date -u +%Y-%m-%dT%H:%M:%SZ) ===" > ${log}`,
+    `echo "remote_dir=${dir}" | tee -a ${log}`,
+    `echo "PATH=$PATH" | tee -a ${log}`,
+    `command -v docker | tee -a ${log}`,
+    `docker version --format '{{.Server.Version}}' 2>&1 | tee -a ${log} || true`,
+    ...dockerConfigExport,
+    ...registryAuthDiagLines,
+    `echo "Resolving compose services (excluding nebula_client)..." | tee -a ${log}`,
+    // No `timeout` wrapper here: pairing timeout with env assignments previously caused
+    // instant failure (timeout treated DOCKER_CONFIG=… as the command). Config is fast;
+    // hung docker is surfaced by the poller's idle/max limits instead.
+    `ALL_SERVICES_RAW=$(docker compose config --services 2>>${log}) && CONFIG_EXIT=0 || CONFIG_EXIT=$?`,
+    `if [ "$CONFIG_EXIT" -ne 0 ]; then`,
+    `  echo "ERROR: docker compose config --services failed (exit $CONFIG_EXIT)" | tee -a ${log}`,
+    `  PIPE_EXIT=$CONFIG_EXIT`,
+    `  exit $PIPE_EXIT`,
+    `fi`,
+    `ALL_SERVICES=$(printf '%s\\n' "$ALL_SERVICES_RAW" | tr '\\n' ' ' | xargs || true)`,
+    `APP_SERVICES=$(printf '%s\\n' "$ALL_SERVICES_RAW" | grep -v '^nebula_client$' | tr '\\n' ' ' | xargs || true)`,
+    `echo "ALL_SERVICES=$ALL_SERVICES" | tee -a ${log}`,
+    `echo "APP_SERVICES=$APP_SERVICES" | tee -a ${log}`,
+    `if [ -n "$APP_SERVICES" ]; then`,
+    // Docker Hub anonymous pulls often 429; retry with backoff before giving up.
+    // Prefer authenticating via registry_auth for docker.io to raise Hub rate limits.
+    `  PULL_MAX_ATTEMPTS=5`,
+    `  PULL_SLEEP=15`,
+    `  PULL_ATTEMPT=1`,
+    `  PULL_EXIT=1`,
+    `  while [ "$PULL_ATTEMPT" -le "$PULL_MAX_ATTEMPTS" ]; do`,
+    `    echo "Pulling: $APP_SERVICES (attempt $PULL_ATTEMPT/$PULL_MAX_ATTEMPTS)" | tee -a ${log}`,
+    `    { docker compose pull $APP_SERVICES; } 2>&1 | tee -a ${log}`,
+    `    PULL_EXIT=\${PIPESTATUS[0]}`,
+    `    if [ "$PULL_EXIT" -eq 0 ]; then`,
+    `      break`,
+    `    fi`,
+    `    if [ "$PULL_ATTEMPT" -ge "$PULL_MAX_ATTEMPTS" ]; then`,
+    `      echo "ERROR: compose pull failed after $PULL_MAX_ATTEMPTS attempts (exit $PULL_EXIT)" | tee -a ${log}`,
+    `      break`,
+    `    fi`,
+    `    echo "Pull failed (exit $PULL_EXIT) — retrying pull after \${PULL_SLEEP}s (rate-limit/429 backoff)" | tee -a ${log}`,
+    `    sleep "$PULL_SLEEP"`,
+    `    PULL_SLEEP=$((PULL_SLEEP * 2))`,
+    `    PULL_ATTEMPT=$((PULL_ATTEMPT + 1))`,
+    `  done`,
+    `  echo "Starting: $APP_SERVICES (pull exit=$PULL_EXIT)" | tee -a ${log}`,
+    `  { docker compose up -d --no-deps $APP_SERVICES; } 2>&1 | tee -a ${log}`,
+    `  UP_EXIT=\${PIPESTATUS[0]}`,
+    `  if [ "$PULL_EXIT" -ne 0 ] || [ "$UP_EXIT" -ne 0 ]; then`,
+    `    echo "ERROR: compose pull/up failed (pull=$PULL_EXIT up=$UP_EXIT)" | tee -a ${log}`,
+    `    PIPE_EXIT=1`,
+    `  else`,
+    `    PIPE_EXIT=0`,
+    `  fi`,
+    `elif [ "$ALL_SERVICES" = "nebula_client" ]; then`,
+    `  echo "Compose has only nebula_client — skipping app pull/up" | tee -a ${log}`,
+    `  PIPE_EXIT=0`,
+    `else`,
+    `  echo "ERROR: no app services resolved from compose config (ALL_SERVICES='$ALL_SERVICES')" | tee -a ${log}`,
+    `  PIPE_EXIT=1`,
+    `  exit $PIPE_EXIT`,
+    `fi`,
+    `if [ "$PIPE_EXIT" -eq 0 ]; then`,
+    `  docker image prune -f 2>&1 | tee -a ${log}`,
+    `fi`,
+    ...ensureNebulaLines,
+    ...postDeployHookLines,
+    `exit $PIPE_EXIT`,
+  ].join("\n");
+}
+
+/**
+ * Start (or replace) a detached screen session running the deploy script via /bin/bash,
+ * with GNU screen output logging so the session transcript survives after exit.
+ */
+export function buildScreenStartCommand(
+  sessionName: string,
+  remoteScriptFile: string,
+  remoteExitFile: string,
+  screenLogFile: string,
+  latestScreenLogFile: string
+): string {
+  const script = shellQuote(remoteScriptFile);
+  const exitFile = shellQuote(remoteExitFile);
+  const session = shellQuote(sessionName);
+  const screenLog = shellQuote(screenLogFile);
+  const latestScreenLog = shellQuote(latestScreenLogFile);
+  return [
+    `screen -S ${sessionName} -X quit 2>/dev/null || true`,
+    `rm -f ${screenLog}`,
+    // -L/-Logfile capture everything printed in the screen window (survives session exit).
+    `screen -L -Logfile ${screenLog} -dmS ${sessionName} /bin/bash ${script}`,
+    "sleep 1",
+    `if screen -ls 2>/dev/null | grep -F ${session} >/dev/null; then`,
+    "  :",
+    `elif [ -f ${exitFile} ]; then`,
+    "  :",
+    "else",
+    `  echo "ERROR: screen session ${sessionName} failed to start" >&2`,
+    "  screen -ls >&2 || true",
+    `  if [ -f ${screenLog} ]; then echo '--- screen log ---' >&2; cat ${screenLog} >&2; fi`,
+    "  exit 1",
+    "fi",
+    // Soft-link/copy path name for operators; refreshed again when polling finishes.
+    `cp -f ${screenLog} ${latestScreenLog} 2>/dev/null || true`,
+  ].join("\n");
+}
+
+export type VmDeployPollScriptInput = {
+  remoteLogFile: string;
+  remoteExitFile: string;
+  remoteScriptFile: string;
+  screenLogFile: string;
+  latestScreenLogFile: string;
+  sessionName: string;
+  /** Seconds with no screen session / no log growth before treating the deploy as stuck. */
+  idleTimeoutSecs: number;
+  /** Absolute ceiling while a live screen session may continue pulling large images. */
+  maxTimeoutSecs: number;
+  /** @deprecated Use idleTimeoutSecs / maxTimeoutSecs. Kept for older call sites. */
+  pollTimeoutSecs?: number;
+};
+
+/**
+ * Poll for the deploy exit file.
+ * While the screen session is alive (e.g. a long image pull), keep waiting up to maxTimeoutSecs.
+ * If the session dies without an exit file, fail after idleTimeoutSecs of no progress.
+ * Preserves `.deploy-latest.log` and `.deploy-latest.screen.log` for SSH debugging.
+ */
+export function buildVmDeployPollScript(input: VmDeployPollScriptInput): string {
+  const log = shellQuote(input.remoteLogFile);
+  const exitFile = shellQuote(input.remoteExitFile);
+  const script = shellQuote(input.remoteScriptFile);
+  const screenLog = shellQuote(input.screenLogFile);
+  const latestScreenLog = shellQuote(input.latestScreenLogFile);
+  const session = shellQuote(input.sessionName);
+  const { sessionName } = input;
+  const idleTimeoutSecs = Math.max(60, input.idleTimeoutSecs);
+  const maxTimeoutSecs = Math.max(idleTimeoutSecs, input.maxTimeoutSecs);
+
+  return [
+    "ELAPSED=0",
+    "IDLE_SECS=0",
+    "LAST_LOG_SIZE=-1",
+    `while [ ! -f ${exitFile} ] && [ "$ELAPSED" -lt ${maxTimeoutSecs} ]; do`,
+    "  sleep 5",
+    "  ELAPSED=$((ELAPSED + 5))",
+    `  if screen -ls 2>/dev/null | grep -F ${session} >/dev/null; then`,
+    "    IDLE_SECS=0",
+    `  elif [ -f ${log} ]; then`,
+    `    LOG_SIZE=$(wc -c < ${log} 2>/dev/null || echo 0)`,
+    `    if [ "$LOG_SIZE" != "$LAST_LOG_SIZE" ]; then`,
+    "      LAST_LOG_SIZE=$LOG_SIZE",
+    "      IDLE_SECS=0",
+    "    else",
+    "      IDLE_SECS=$((IDLE_SECS + 5))",
+    "    fi",
+    "  else",
+    "    IDLE_SECS=$((IDLE_SECS + 5))",
+    "  fi",
+    `  if [ "$IDLE_SECS" -ge ${idleTimeoutSecs} ]; then`,
+    "    break",
+    "  fi",
+    "done",
+    // Always refresh the durable screen transcript for operators.
+    `cp -f ${screenLog} ${latestScreenLog} 2>/dev/null || true`,
+    `if [ -f ${exitFile} ]; then`,
+    `  EXIT_CODE=$(cat ${exitFile})`,
+    `  echo '--- deploy log ---'`,
+    `  cat ${log} 2>/dev/null || true`,
+    `  echo '--- screen log ---'`,
+    `  cat ${screenLog} 2>/dev/null || echo '(no screen log)'`,
+    // Remove per-run artifacts; keep .deploy-latest.log and .deploy-latest.screen.log.
+    `  rm -f ${script} ${log} ${exitFile} ${screenLog}`,
+    `  exit "$EXIT_CODE"`,
+    "else",
+    `  printf 'Timed out after %ds (idle %ds / max %ds) — docker compose may still be running in screen session: %s\\n' "$ELAPSED" "$IDLE_SECS" ${maxTimeoutSecs} ${sessionName}`,
+    `  echo '--- screen sessions ---'`,
+    "  screen -ls 2>&1 || true",
+    `  echo '--- deploy artifacts ---'`,
+    `  ls -la ${script} ${log} ${exitFile} ${screenLog} 2>&1 || true`,
+    `  echo '--- deploy log ---'`,
+    `  if [ -f ${log} ]; then cat ${log}; else echo '(no log file — deploy script may not have started)'; fi`,
+    `  echo '--- screen log ---'`,
+    `  if [ -f ${screenLog} ]; then cat ${screenLog}; else echo '(no screen log)'; fi`,
+    "  exit 1",
+    "fi",
+  ].join("\n");
+}

--- a/src/services/ssh-deployer.test.ts
+++ b/src/services/ssh-deployer.test.ts
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildDockerConfigContent,
+  DOCKER_HUB_CONFIG_KEY,
+  normalizeDockerRegistryKey
+} from "./docker-registry-auth.js";
+import {
+  buildScreenStartCommand,
+  buildVmDeployPollScript,
+  buildVmDeployScript
+} from "./ssh-deploy-scripts.js";
+
+const paths = {
+  remoteDir: "/home/kumpeapps-bot-deploy",
+  remoteLogFile: "/home/kumpeapps-bot-deploy/.deploy-kumpeapps-deploy-1.log",
+  remoteExitFile: "/home/kumpeapps-bot-deploy/.deploy-kumpeapps-deploy-1.exit",
+  remoteScriptFile: "/home/kumpeapps-bot-deploy/.deploy-kumpeapps-deploy-1.sh",
+  screenLogFile: "/home/kumpeapps-bot-deploy/.deploy-kumpeapps-deploy-1.screen.log",
+  latestScreenLogFile: "/home/kumpeapps-bot-deploy/.deploy-latest.screen.log",
+  sessionName: "kumpeapps-deploy-1",
+  idleTimeoutSecs: 600,
+  maxTimeoutSecs: 3600
+};
+
+describe("normalizeDockerRegistryKey", () => {
+  it("maps Docker Hub aliases to the config.json key Docker expects", () => {
+    for (const alias of ["docker.io", "index.docker.io", "registry-1.docker.io", "https://index.docker.io/v1/"]) {
+      assert.equal(normalizeDockerRegistryKey(alias), DOCKER_HUB_CONFIG_KEY);
+    }
+  });
+
+  it("keeps non-Hub registries as hostnames", () => {
+    assert.equal(normalizeDockerRegistryKey("ghcr.io"), "ghcr.io");
+    assert.equal(normalizeDockerRegistryKey("https://ghcr.io"), "ghcr.io");
+  });
+});
+
+describe("buildDockerConfigContent", () => {
+  it("stores Hub auth under https://index.docker.io/v1/ even when configured as docker.io", () => {
+    const parsed = JSON.parse(
+      buildDockerConfigContent([{ registry: "docker.io", username: "alice", password: "secret" }])
+    );
+    assert.ok(parsed.auths[DOCKER_HUB_CONFIG_KEY]);
+    assert.equal(parsed.auths[DOCKER_HUB_CONFIG_KEY].auth, Buffer.from("alice:secret").toString("base64"));
+    assert.equal(parsed.auths["docker.io"], undefined);
+  });
+});
+
+describe("buildVmDeployScript", () => {
+  it("writes a start marker to the log before any docker compose commands", () => {
+    const script = buildVmDeployScript(paths);
+    const startIdx = script.indexOf("deploy started");
+    const composeIdx = script.indexOf("docker compose config");
+    assert.ok(startIdx >= 0, "expected deploy started log marker");
+    assert.ok(composeIdx > startIdx, "log marker must precede docker compose config");
+  });
+
+  it("installs an EXIT trap that writes exit file and copies a persistent latest log", () => {
+    const script = buildVmDeployScript(paths);
+    assert.match(script, /trap write_exit EXIT/);
+    assert.match(script, /write_exit\(\)/);
+    assert.ok(script.includes(paths.remoteExitFile));
+    assert.match(script, /\.deploy-latest\.log/);
+    assert.match(script, /cp -f/);
+  });
+
+  it("does not wrap compose config in timeout (avoids DOCKER_CONFIG assignment bugs)", () => {
+    const script = buildVmDeployScript({
+      ...paths,
+      dockerConfigDir: "/home/kumpeapps-bot-deploy/.docker"
+    });
+    assert.match(script, /export DOCKER_CONFIG='\/home\/kumpeapps-bot-deploy\/\.docker'/);
+    assert.equal(script.includes("CONFIG_TIMEOUT"), false);
+    assert.equal(script.includes("timeout 60"), false);
+    assert.match(script, /docker compose config --services/);
+  });
+
+  it("excludes nebula_client from app pull/up but still ensures it is running", () => {
+    const script = buildVmDeployScript(paths);
+    assert.match(script, /grep -v '\^nebula_client\$'/);
+    assert.match(script, /docker compose up -d --no-deps \$APP_SERVICES/);
+    assert.equal(script.includes("--pull never"), false);
+    assert.match(script, /Ensuring nebula_client is running/);
+    assert.match(script, /docker compose up -d --no-deps --no-recreate nebula_client/);
+    const excludeIdx = script.indexOf("grep -v '^nebula_client$'");
+    const ensureIdx = script.indexOf("Ensuring nebula_client is running");
+    assert.ok(excludeIdx >= 0 && ensureIdx > excludeIdx, "ensure step must run after app services");
+  });
+
+  it("fails the deploy when compose config yields no app services (unless only nebula_client)", () => {
+    const script = buildVmDeployScript(paths);
+    assert.match(script, /ALL_SERVICES=/);
+    assert.match(script, /CONFIG_EXIT/);
+    assert.match(script, /docker compose config --services failed/);
+    assert.match(script, /no app services resolved/);
+    assert.match(script, /only nebula_client/);
+  });
+
+  it("always pulls then ups, and fails if either pull or up fails", () => {
+    const script = buildVmDeployScript(paths);
+    assert.match(script, /PULL_EXIT=/);
+    assert.match(script, /UP_EXIT=/);
+    assert.equal(script.includes("--pull never"), false);
+    assert.match(script, /docker compose pull \$APP_SERVICES/);
+    assert.match(script, /docker compose up -d --no-deps \$APP_SERVICES/);
+    assert.match(script, /compose pull\/up failed/);
+  });
+
+  it("logs registry auth status so operators can tell if Docker Hub login applied", () => {
+    const script = buildVmDeployScript({
+      ...paths,
+      dockerConfigDir: "/home/kumpeapps-bot-deploy/.docker"
+    });
+    assert.match(script, /registry_auth_keys=/);
+    assert.match(script, /Docker Hub login/);
+    assert.match(script, /index\.docker\.io\/v1/);
+  });
+
+  it("warns when DOCKER_CONFIG is unset so anonymous Hub pulls are obvious", () => {
+    const script = buildVmDeployScript(paths);
+    assert.match(script, /DOCKER_CONFIG=\(default\)/);
+    assert.match(script, /no Docker registry auth config/);
+  });
+
+  it("retries compose pull with backoff to survive Docker Hub 429s", () => {
+    const script = buildVmDeployScript(paths);
+    assert.match(script, /PULL_ATTEMPT=/);
+    assert.match(script, /PULL_MAX_ATTEMPTS=/);
+    assert.match(script, /sleep "\$PULL_SLEEP"/);
+    assert.match(script, /rate-limit\/429 backoff/);
+  });
+
+  it("exports a sane PATH so docker is found inside screen", () => {
+    const script = buildVmDeployScript(paths);
+    assert.match(script, /export PATH="\/usr\/local\/sbin:/);
+    assert.match(script, /command -v docker/);
+  });
+});
+
+describe("buildScreenStartCommand", () => {
+  it("enables screen logfile capture and verifies the session or exit file", () => {
+    const cmd = buildScreenStartCommand(
+      paths.sessionName,
+      paths.remoteScriptFile,
+      paths.remoteExitFile,
+      paths.screenLogFile,
+      paths.latestScreenLogFile
+    );
+    assert.match(cmd, /screen -L -Logfile/);
+    assert.ok(cmd.includes(paths.screenLogFile));
+    assert.ok(cmd.includes(paths.latestScreenLogFile));
+    assert.match(cmd, /-dmS kumpeapps-deploy-1 \/bin\/bash/);
+    assert.ok(cmd.includes(paths.remoteScriptFile));
+    assert.match(cmd, /screen -ls/);
+    assert.ok(cmd.includes(paths.remoteExitFile));
+    assert.match(cmd, /failed to start/);
+  });
+});
+
+describe("buildVmDeployPollScript", () => {
+  it("keeps waiting while the screen session is alive so slow image pulls do not time out", () => {
+    const script = buildVmDeployPollScript(paths);
+    assert.match(script, /screen -ls/);
+    assert.match(script, /IDLE_SECS/);
+    assert.ok(script.includes(String(paths.idleTimeoutSecs)));
+    assert.ok(script.includes(String(paths.maxTimeoutSecs)));
+    assert.match(script, /grep -F/);
+    assert.match(script, /IDLE_SECS=0/);
+  });
+
+  it("emits deploy and screen log diagnostics on timeout", () => {
+    const script = buildVmDeployPollScript(paths);
+    assert.match(script, /Timed out after/);
+    assert.match(script, /--- screen sessions ---/);
+    assert.match(script, /--- deploy artifacts ---/);
+    assert.match(script, /--- deploy log ---/);
+    assert.match(script, /--- screen log ---/);
+    assert.ok(script.includes(paths.remoteLogFile));
+    assert.ok(script.includes(paths.screenLogFile));
+    assert.ok(script.includes(paths.latestScreenLogFile));
+  });
+
+  it("returns the remote exit code, prints both logs, and keeps latest screen log", () => {
+    const script = buildVmDeployPollScript(paths);
+    assert.match(script, /EXIT_CODE=\$\(cat/);
+    assert.match(script, /--- screen log ---/);
+    assert.match(script, /cp -f/);
+    assert.match(script, /\.deploy-latest\.screen\.log/);
+    assert.match(script, /rm -f/);
+    assert.ok(script.includes(paths.remoteScriptFile));
+  });
+});

--- a/src/services/ssh-deployer.ts
+++ b/src/services/ssh-deployer.ts
@@ -5,6 +5,21 @@ import { promisify } from "node:util";
 import { execFile } from "node:child_process";
 import { appConfig } from "../config.js";
 import { recordSshCommandAttempt, recordSshCommandFinalFailure, recordSshCommandSuccess } from "./ssh-health.js";
+import {
+  buildScreenStartCommand,
+  buildVmDeployPollScript,
+  buildVmDeployScript
+} from "./ssh-deploy-scripts.js";
+import { buildDockerConfigContent } from "./docker-registry-auth.js";
+import { insecureRegistryHostsFromDockerInfo, registryMirrorsFromDockerInfo } from "./docker-registry-mirror.js";
+
+export {
+  buildEnsureNebulaClientLines,
+  buildScreenStartCommand,
+  buildVmDeployPollScript,
+  buildVmDeployScript
+} from "./ssh-deploy-scripts.js";
+export type { VmDeployPollScriptInput, VmDeployScriptInput } from "./ssh-deploy-scripts.js";
 
 export type VmDeployInput = {
   vmHostname: string;
@@ -69,23 +84,6 @@ function envFileContent(envValues: Record<string, string>): string {
   return Object.entries(envValues)
     .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
     .join("\n");
-}
-
-function dockerConfigContent(registryLogins: Array<{ registry: string; username: string; password: string }>): string {
-  const auths: Record<string, { auth: string }> = {};
-
-  for (const login of registryLogins) {
-    const key = login.registry.trim();
-    if (!key) {
-      continue;
-    }
-
-    auths[key] = {
-      auth: Buffer.from(`${login.username}:${login.password}`, "utf8").toString("base64")
-    };
-  }
-
-  return JSON.stringify({ auths });
 }
 
 function commonSshArgs(input: { sshKeyPath: string; sshPort: number }): string[] {
@@ -183,21 +181,50 @@ async function copyToRemote(input: RemoteCommandOptions, localPath: string, remo
 }
 
 /**
- * Build the shell lines that run an operator-configured post-deploy hook.
- * Runs only when the main compose step exits 0; hook exit code is logged but
- * does not override the deployment result.
+ * Probe docker RegistryConfig via `docker info` (no sudo / daemon.json access required).
+ * Returns empty sets on failure so callers skip mirror usage (safe fallback).
  */
-function buildPostDeployHookLines(remoteLogFile: string, postDeployHook?: string): string[] {
-  if (!postDeployHook) return [];
+export async function probeVmDockerRegistryConfig(input: {
+  vmIp: string;
+  sshUser: string;
+  sshKeyPath: string;
+  sshPort: number;
+  dryRun?: boolean;
+}): Promise<{ insecureHosts: Set<string>; registryMirrors: string[] }> {
+  if (input.dryRun) {
+    return { insecureHosts: new Set(), registryMirrors: [] };
+  }
 
-  return [
-    `if [ "$PIPE_EXIT" -eq 0 ]; then`,
-    `  echo "--- Running post-deploy hook ---" | tee -a ${shellQuote(remoteLogFile)}`,
-    `  { ${postDeployHook}; } 2>&1 | tee -a ${shellQuote(remoteLogFile)}`,
-    `  HOOK_EXIT=$?`,
-    `  if [ "$HOOK_EXIT" -ne 0 ]; then echo "Post-deploy hook exited $HOOK_EXIT" | tee -a ${shellQuote(remoteLogFile)}; fi`,
-    `fi`,
-  ];
+  try {
+    const { stdout } = await runRemoteSsh(
+      {
+        sshUser: input.sshUser,
+        sshKeyPath: input.sshKeyPath,
+        sshPort: input.sshPort,
+        host: input.vmIp
+      },
+      "docker info --format '{{json .RegistryConfig}}' 2>/dev/null || echo '{}'"
+    );
+    const raw = stdout.trim() || "{}";
+    return {
+      insecureHosts: insecureRegistryHostsFromDockerInfo(raw),
+      registryMirrors: registryMirrorsFromDockerInfo(raw)
+    };
+  } catch {
+    return { insecureHosts: new Set(), registryMirrors: [] };
+  }
+}
+
+/** @deprecated Use probeVmDockerRegistryConfig */
+export async function probeVmInsecureRegistryHosts(input: {
+  vmIp: string;
+  sshUser: string;
+  sshKeyPath: string;
+  sshPort: number;
+  dryRun?: boolean;
+}): Promise<Set<string>> {
+  const { insecureHosts } = await probeVmDockerRegistryConfig(input);
+  return insecureHosts;
 }
 
 export async function deployComposeToVm(input: VmDeployInput): Promise<string> {
@@ -216,7 +243,7 @@ export async function deployComposeToVm(input: VmDeployInput): Promise<string> {
     await writeFile(composePath, input.composeConfig, "utf8");
     await writeFile(envPath, envFileContent(input.envValues), "utf8");
     if (hasRegistryLogins && input.registryLogins) {
-      await writeFile(dockerConfigPath, dockerConfigContent(input.registryLogins), "utf8");
+      await writeFile(dockerConfigPath, buildDockerConfigContent(input.registryLogins), "utf8");
     }
 
     await runRemoteSsh(
@@ -289,7 +316,7 @@ export async function deployComposeToVm(input: VmDeployInput): Promise<string> {
       );
     }
 
-    const dockerConfigPrefix = hasRegistryLogins ? `DOCKER_CONFIG=${shellQuote(`${remoteDir}/.docker`)} ` : "";
+    const dockerConfigDir = hasRegistryLogins ? `${remoteDir}/.docker` : undefined;
 
     // Build a deploy script that runs docker compose pull + up -d inside a screen session.
     // Running inside screen means the docker commands survive SSH disconnects; we then poll
@@ -300,34 +327,19 @@ export async function deployComposeToVm(input: VmDeployInput): Promise<string> {
     const remoteLogFile = `${remoteDir}/.deploy-${sessionName}.log`;
     const remoteExitFile = `${remoteDir}/.deploy-${sessionName}.exit`;
     const remoteScriptFile = `${remoteDir}/.deploy-${sessionName}.sh`;
+    const remoteScreenLogFile = `${remoteDir}/.deploy-${sessionName}.screen.log`;
+    const latestScreenLogFile = `${remoteDir}/.deploy-latest.screen.log`;
     const scriptLocalPath = join(workDir, "deploy.sh");
+    const idleTimeoutSecs = appConfig.SSH_DOCKER_COMMAND_TIMEOUT_SECONDS;
+    const maxTimeoutSecs = Math.max(idleTimeoutSecs, appConfig.SSH_DOCKER_DEPLOY_MAX_SECONDS);
 
-    const postDeployHookLines = buildPostDeployHookLines(remoteLogFile, input.postDeployHook);
-
-    const deployScript = [
-      "#!/bin/bash",
-      "set -o pipefail",
-      `cd ${shellQuote(remoteDir)}`,
-      `rm -f ${shellQuote(remoteExitFile)} ${shellQuote(remoteLogFile)}`,
-      // Exclude nebula_client from all compose operations to avoid disrupting the VPN tunnel.
-      // --no-deps is also required: without it, `docker compose up -d` follows depends_on and
-      // may recreate nebula_client if the freshly SCP'd .env or docker-compose.yml caused a
-      // config diff, even when nebula_client is not in the explicit service list.
-      `APP_SERVICES=$(${dockerConfigPrefix}docker compose config --services 2>/dev/null | grep -v '^nebula_client$' | tr '\\n' ' ' | xargs)`,
-      `if [ -n "$APP_SERVICES" ]; then`,
-      `  { ${dockerConfigPrefix}docker compose pull $APP_SERVICES && ${dockerConfigPrefix}docker compose up -d --no-deps $APP_SERVICES; } 2>&1 | tee ${shellQuote(remoteLogFile)}`,
-      `  PIPE_EXIT=\${PIPESTATUS[0]}`,
-      `else`,
-      `  { ${dockerConfigPrefix}docker compose pull && ${dockerConfigPrefix}docker compose up -d --no-deps; } 2>&1 | tee ${shellQuote(remoteLogFile)}`,
-      `  PIPE_EXIT=\${PIPESTATUS[0]}`,
-      `fi`,
-      `if [ "$PIPE_EXIT" -eq 0 ]; then`,
-      `  docker image prune -f 2>&1 | tee -a ${shellQuote(remoteLogFile)}`,
-      `fi`,
-      ...postDeployHookLines,
-      `echo $PIPE_EXIT > ${shellQuote(remoteExitFile)}`,
-      `exit $PIPE_EXIT`,
-    ].join("\n");
+    const deployScript = buildVmDeployScript({
+      remoteDir,
+      remoteLogFile,
+      remoteExitFile,
+      dockerConfigDir,
+      postDeployHook: input.postDeployHook
+    });
 
     await writeFile(scriptLocalPath, deployScript, "utf8");
 
@@ -348,37 +360,35 @@ export async function deployComposeToVm(input: VmDeployInput): Promise<string> {
       `chmod +x ${shellQuote(remoteScriptFile)}`
     );
 
-    // Kill any lingering prior session then start a new detached screen session
+    // Kill any lingering prior session then start a new detached screen session (with logfile).
     await runRemoteSsh(
       { sshUser: input.sshUser, sshKeyPath: input.sshKeyPath, sshPort: input.sshPort, host: input.vmIp },
-      `screen -S ${sessionName} -X quit 2>/dev/null; screen -dmS ${sessionName} ${shellQuote(remoteScriptFile)}`
+      buildScreenStartCommand(
+        sessionName,
+        remoteScriptFile,
+        remoteExitFile,
+        remoteScreenLogFile,
+        latestScreenLogFile
+      )
     );
 
-    // Poll (via a separate SSH connection) until the exit file appears or we time out.
-    // If the polling SSH connection drops, the screen session on the VM continues running.
-    const pollTimeoutSecs = appConfig.SSH_DOCKER_COMMAND_TIMEOUT_SECONDS;
-    const pollScript = [
-      `ELAPSED=0`,
-      `while [ ! -f ${shellQuote(remoteExitFile)} ] && [ "$ELAPSED" -lt ${pollTimeoutSecs} ]; do`,
-      `  sleep 5`,
-      `  ELAPSED=$((ELAPSED + 5))`,
-      `done`,
-      `if [ -f ${shellQuote(remoteExitFile)} ]; then`,
-      `  EXIT_CODE=$(cat ${shellQuote(remoteExitFile)})`,
-      `  cat ${shellQuote(remoteLogFile)} 2>/dev/null || true`,
-      `  rm -f ${shellQuote(remoteScriptFile)} ${shellQuote(remoteLogFile)} ${shellQuote(remoteExitFile)}`,
-      `  exit "$EXIT_CODE"`,
-      `else`,
-      `  printf 'Timed out after %ds — docker compose may still be running in screen session: %s\\n' ${pollTimeoutSecs} ${sessionName}`,
-      `  cat ${shellQuote(remoteLogFile)} 2>/dev/null || true`,
-      `  exit 1`,
-      `fi`,
-    ].join("\n");
+    // Poll until the exit file appears. While the screen session is alive (slow pulls),
+    // keep waiting up to maxTimeoutSecs; only idle-timeout when progress has stopped.
+    const pollScript = buildVmDeployPollScript({
+      remoteLogFile,
+      remoteExitFile,
+      remoteScriptFile,
+      screenLogFile: remoteScreenLogFile,
+      latestScreenLogFile,
+      sessionName,
+      idleTimeoutSecs,
+      maxTimeoutSecs
+    });
 
     const { stdout } = await runRemoteSsh(
       { sshUser: input.sshUser, sshKeyPath: input.sshKeyPath, sshPort: input.sshPort, host: input.vmIp },
       pollScript,
-      (appConfig.SSH_DOCKER_COMMAND_TIMEOUT_SECONDS + 30) * 1000
+      (maxTimeoutSecs + 60) * 1000
     );
 
     // For new deployments, enable and start the systemctl service so it is registered for

--- a/src/services/vm-approval.test.ts
+++ b/src/services/vm-approval.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { resolvePreferredIssueTypeName } from "./github-issue-types.js";
+
+describe("resolvePreferredIssueTypeName", () => {
+  it("returns the canonical Task name when enabled", () => {
+    assert.equal(
+      resolvePreferredIssueTypeName([
+        { name: "Bug", is_enabled: true },
+        { name: "Task", is_enabled: true },
+        { name: "Feature", is_enabled: true }
+      ]),
+      "Task"
+    );
+  });
+
+  it("matches preferred name case-insensitively", () => {
+    assert.equal(
+      resolvePreferredIssueTypeName([{ name: "task", is_enabled: true }], "Task"),
+      "task"
+    );
+  });
+
+  it("returns undefined when Task is missing or disabled", () => {
+    assert.equal(
+      resolvePreferredIssueTypeName([{ name: "Bug", is_enabled: true }, { name: "Feature", is_enabled: true }]),
+      undefined
+    );
+    assert.equal(
+      resolvePreferredIssueTypeName([{ name: "Task", is_enabled: false }]),
+      undefined
+    );
+  });
+});

--- a/src/services/vm-approval.ts
+++ b/src/services/vm-approval.ts
@@ -2,6 +2,12 @@ import { prisma } from "../db.js";
 import { appConfig } from "../config.js";
 import { getGitHubToken } from "./github-app-auth.js";
 import { triggerQueuePoll } from "./deployment-queue.js";
+import {
+  resolvePreferredIssueTypeName,
+  type GitHubIssueType
+} from "./github-issue-types.js";
+
+export { resolvePreferredIssueTypeName } from "./github-issue-types.js";
 
 type CreateApprovalInput = {
   repositoryFullName: string;
@@ -19,6 +25,38 @@ type CreateApprovalInput = {
 };
 
 type ApprovalStatus = "pending" | "approved" | "rejected" | "cancelled";
+
+async function fetchRepositoryIssueTypes(input: {
+  owner: string;
+  name: string;
+  token: string;
+}): Promise<GitHubIssueType[]> {
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${encodeURIComponent(input.owner)}/${encodeURIComponent(input.name)}/issue-types`,
+      {
+        headers: {
+          Authorization: `Bearer ${input.token}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          "User-Agent": "kumpeapps-deployment-bot"
+        },
+        signal: AbortSignal.timeout(15000)
+      }
+    );
+    if (!response.ok) {
+      console.warn(
+        `[VM Approval] Could not list issue types for ${input.owner}/${input.name}: HTTP ${response.status}`
+      );
+      return [];
+    }
+    const types = (await response.json()) as GitHubIssueType[];
+    return Array.isArray(types) ? types : [];
+  } catch (error) {
+    console.warn(`[VM Approval] Failed to list issue types:`, error);
+    return [];
+  }
+}
 
 export async function createVmApprovalRequest(input: CreateApprovalInput): Promise<number> {
   const [owner, name] = input.repositoryFullName.split('/');
@@ -85,19 +123,29 @@ A new virtual machine is requested for this repository.
 
 **Note:** Only you (@${input.assignedUsername}) can approve this request. Bot admins may also override with \`/bot approve admin-override\`. The VM will be created automatically once approved.`;
 
+  const issueTypes = await fetchRepositoryIssueTypes({ owner, name, token });
+  const issueType = resolvePreferredIssueTypeName(issueTypes, "Task");
+  if (issueType) {
+    console.log(`[VM Approval] Using issue type "${issueType}" for approval issue`);
+  } else {
+    console.log(`[VM Approval] Issue type Task not available; creating issue without type`);
+  }
 
   const issueResponse = await fetch(`https://api.github.com/repos/${owner}/${name}/issues`, {
     method: 'POST',
     headers: {
       'Authorization': `Bearer ${token}`,
       'Accept': 'application/vnd.github+json',
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'kumpeapps-deployment-bot'
     },
     body: JSON.stringify({
       title: `[VM Approval] ${input.environment} VM for @${input.assignedUsername}`,
       body: issueBody,
       labels: ['vm-approval', 'task'],
-      assignees: [input.assignedUsername]
+      assignees: [input.assignedUsername],
+      ...(issueType ? { type: issueType } : {})
     })
   });
   


### PR DESCRIPTION
## Summary by Sourcery

Refactor VM SSH deployment flow into reusable script builders, harden deploy behavior around timeouts and nebula_client, and add targeted tests and AI tooling metadata.

New Features:
- Introduce reusable builders for remote VM deploy scripts, screen session startup, and deploy polling logic that can be consumed by other parts of the app or tooling.
- Add configurable maximum deploy duration alongside the existing idle timeout to distinguish between lack of progress and long-running image pulls.
- Expose deployment script builder utilities and types from the SSH deployer service for external use.

Bug Fixes:
- Prevent premature SSH deploy timeouts by continuing to wait while the screen session is alive, treating only log-idle or session-less periods as stuck.
- Ensure nebula_client is kept running without pulling or recreating it during app deploys, avoiding disruption of the VPN tunnel.
- Guarantee deploy exit files are written even when docker commands hang and are killed, avoiding misleading timeout errors with no log output.

Enhancements:
- Extract SSH VM deploy shell construction into a dedicated, side-effect-free module to simplify the main deployer service and improve testability.
- Improve deploy logging and diagnostics, including start markers, explicit service resolution logs, and richer timeout diagnostics on failure.
- Tighten screen session startup checks so failed session launches are detected early with clearer error output.

Build:
- Register the new SSH deployer test suite in the npm test script.

Tests:
- Add unit tests covering generated deploy scripts, screen start commands, and polling scripts to validate timeouts, nebula_client handling, and diagnostics behavior.

Chores:
- Add AI assistant configuration files and skills definitions (Cursor rules, skills, and AI agent skills metadata) plus git submodules configuration to support development tooling.

<!-- kumpeapps-issue-autoclose -->
Closes #56